### PR TITLE
Segmented stack LLVM tests for ARM

### DIFF
--- a/test/CodeGen/ARM/segmented-stacks-dynamic.ll
+++ b/test/CodeGen/ARM/segmented-stacks-dynamic.ll
@@ -1,0 +1,44 @@
+; RUN: llc < %s -mcpu=generic -march=arm -segmented-stacks -verify-machineinstrs | FileCheck %s -check-prefix=ARM-Generic
+; RUN: llc < %s -mcpu=generic -march=arm -segmented-stacks -filetype=obj
+
+; Just to prevent the alloca from being optimized away
+declare void @dummy_use(i32*, i32)
+
+define i32 @test_basic(i32 %l) {
+        %mem = alloca i32, i32 %l
+        call void @dummy_use (i32* %mem, i32 %l)
+        %terminate = icmp eq i32 %l, 0
+        br i1 %terminate, label %true, label %false
+
+true:
+        ret i32 0
+
+false:
+        %newlen = sub i32 %l, 1
+        %retvalue = call i32 @test_basic(i32 %newlen)
+        ret i32 %retvalue
+
+; ARM-Generic:      test_basic:
+
+; ARM-Generic:      push    {r4, r5}
+; ARM-Generic-NEXT: mrc     p15, #0, r4, c13, c0, #3
+; ARM-Generic-NEXT: mov     r5, sp
+; ARM-Generic-NEXT: cmp     r4, #0
+; ARM-Generic-NEXT: mvneq   r4, #61440
+; ARM-Generic-NEXT: ldreq   r4, [r4, #-15]
+; ARM-Generic-NEXT: add     r4, r4, #4
+; ARM-Generic-NEXT: ldr     r4, [r4]
+; ARM-Generic-NEXT: cmp     r4, r5
+; ARM-Generic-NEXT: blo     .LBB0_2
+
+; ARM-Generic:      mov     r4, #16
+; ARM-Generic-NEXT: mov     r5, #0
+; ARM-Generic-NEXT: stmdb   sp!, {lr}
+; ARM-Generic-NEXT: bl      __morestack
+; ARM-Generic-NEXT: ldm     sp!, {lr}
+; ARM-Generic-NEXT: pop     {r4, r5}
+; ARM-Generic-NEXT: mov     pc, lr
+
+; ARM-Generic:      pop     {r4, r5}
+
+}

--- a/test/CodeGen/ARM/segmented-stacks-dynamic.ll
+++ b/test/CodeGen/ARM/segmented-stacks-dynamic.ll
@@ -1,5 +1,5 @@
-; RUN: llc < %s -mcpu=generic -march=arm -segmented-stacks -verify-machineinstrs | FileCheck %s -check-prefix=ARM-Generic
-; RUN: llc < %s -mcpu=generic -march=arm -segmented-stacks -filetype=obj
+; RUN: llc < %s -mtriple=arm-linux-android -segmented-stacks -verify-machineinstrs | FileCheck %s -check-prefix=ARM-Linux-Android
+; RUN: llc < %s -mtriple=arm-linux-android -segmented-stacks -filetype=obj
 
 ; Just to prevent the alloca from being optimized away
 declare void @dummy_use(i32*, i32)
@@ -18,27 +18,27 @@ false:
         %retvalue = call i32 @test_basic(i32 %newlen)
         ret i32 %retvalue
 
-; ARM-Generic:      test_basic:
+; ARM-Linux-Android:      test_basic:
 
-; ARM-Generic:      push    {r4, r5}
-; ARM-Generic-NEXT: mrc     p15, #0, r4, c13, c0, #3
-; ARM-Generic-NEXT: mov     r5, sp
-; ARM-Generic-NEXT: cmp     r4, #0
-; ARM-Generic-NEXT: mvneq   r4, #61440
-; ARM-Generic-NEXT: ldreq   r4, [r4, #-15]
-; ARM-Generic-NEXT: add     r4, r4, #4
-; ARM-Generic-NEXT: ldr     r4, [r4]
-; ARM-Generic-NEXT: cmp     r4, r5
-; ARM-Generic-NEXT: blo     .LBB0_2
+; ARM-Linux-Android:      push    {r4, r5}
+; ARM-Linux-Android-NEXT: mrc     p15, #0, r4, c13, c0, #3
+; ARM-Linux-Android-NEXT: mov     r5, sp
+; ARM-Linux-Android-NEXT: cmp     r4, #0
+; ARM-Linux-Android-NEXT: mvneq   r4, #61440
+; ARM-Linux-Android-NEXT: ldreq   r4, [r4, #-15]
+; ARM-Linux-Android-NEXT: add     r4, r4, #252
+; ARM-Linux-Android-NEXT: ldr     r4, [r4]
+; ARM-Linux-Android-NEXT: cmp     r4, r5
+; ARM-Linux-Android-NEXT: blo     .LBB0_2
 
-; ARM-Generic:      mov     r4, #16
-; ARM-Generic-NEXT: mov     r5, #0
-; ARM-Generic-NEXT: stmdb   sp!, {lr}
-; ARM-Generic-NEXT: bl      __morestack
-; ARM-Generic-NEXT: ldm     sp!, {lr}
-; ARM-Generic-NEXT: pop     {r4, r5}
-; ARM-Generic-NEXT: mov     pc, lr
+; ARM-Linux-Android:      mov     r4, #24
+; ARM-Linux-Android-NEXT: mov     r5, #0
+; ARM-Linux-Android-NEXT: stmdb   sp!, {lr}
+; ARM-Linux-Android-NEXT: bl      __morestack
+; ARM-Linux-Android-NEXT: ldm     sp!, {lr}
+; ARM-Linux-Android-NEXT: pop     {r4, r5}
+; ARM-Linux-Android-NEXT: mov     pc, lr
 
-; ARM-Generic:      pop     {r4, r5}
+; ARM-Linux-Android:      pop     {r4, r5}
 
 }

--- a/test/CodeGen/ARM/segmented-stacks.ll
+++ b/test/CodeGen/ARM/segmented-stacks.ll
@@ -1,0 +1,158 @@
+; RUN: llc < %s -mcpu=generic -march=arm -segmented-stacks -verify-machineinstrs | FileCheck %s -check-prefix=ARM-Generic
+
+; We used to crash with filetype=obj
+; RUN: llc < %s -mcpu=generic -march=arm -segmented-stacks -filetype=obj
+
+
+; Just to prevent the alloca from being optimized away
+declare void @dummy_use(i32*, i32)
+
+define void @test_basic() {
+        %mem = alloca i32, i32 10
+        call void @dummy_use (i32* %mem, i32 10)
+	ret void
+
+; ARM-Generic:      test_basic:
+
+; ARM-Generic:      push    {r4, r5}
+; ARM-Generic-NEXT: mrc     p15, #0, r4, c13, c0, #3
+; ARM-Generic-NEXT: mov     r5, sp
+; ARM-Generic-NEXT: cmp     r4, #0
+; ARM-Generic-NEXT: mvneq   r4, #61440
+; ARM-Generic-NEXT: ldreq   r4, [r4, #-15]
+; ARM-Generic-NEXT: add     r4, r4, #4
+; ARM-Generic-NEXT: ldr     r4, [r4]
+; ARM-Generic-NEXT: cmp     r4, r5
+; ARM-Generic-NEXT: blo     .LBB0_2
+
+; ARM-Generic:      mov     r4, #44
+; ARM-Generic-NEXT: mov     r5, #0
+; ARM-Generic-NEXT: stmdb   sp!, {lr}
+; ARM-Generic-NEXT: bl      __morestack
+; ARM-Generic-NEXT: ldm     sp!, {lr}
+; ARM-Generic-NEXT: pop     {r4, r5}
+; ARM-Generic-NEXT: mov     pc, lr
+
+; ARM-Generic:      pop     {r4, r5}
+
+}
+
+define i32 @test_nested(i32 * nest %closure, i32 %other) {
+       %addend = load i32 * %closure
+       %result = add i32 %other, %addend
+       ret i32 %result
+
+; ARM-Generic:      test_nested:
+
+; ARM-Generic:      push    {r4, r5}
+; ARM-Generic-NEXT: mrc     p15, #0, r4, c13, c0, #3
+; ARM-Generic-NEXT: mov     r5, sp
+; ARM-Generic-NEXT: cmp     r4, #0
+; ARM-Generic-NEXT: mvneq   r4, #61440
+; ARM-Generic-NEXT: ldreq   r4, [r4, #-15]
+; ARM-Generic-NEXT: add     r4, r4, #4
+; ARM-Generic-NEXT: ldr     r4, [r4]
+; ARM-Generic-NEXT: cmp     r4, r5
+; ARM-Generic-NEXT: blo     .LBB1_2
+
+; ARM-Generic:      mov     r4, #0
+; ARM-Generic-NEXT: mov     r5, #0
+; ARM-Generic-NEXT: stmdb   sp!, {lr}
+; ARM-Generic-NEXT: bl      __morestack
+; ARM-Generic-NEXT: ldm     sp!, {lr}
+; ARM-Generic-NEXT: pop     {r4, r5}
+; ARM-Generic-NEXT: mov     pc, lr
+
+; ARM-Generic:      pop     {r4, r5}
+
+}
+
+define void @test_large() {
+        %mem = alloca i32, i32 10000
+        call void @dummy_use (i32* %mem, i32 0)
+        ret void
+
+; ARM-Generic:      test_large:
+
+; ARM-Generic:      push    {r4, r5}
+; ARM-Generic-NEXT: mrc     p15, #0, r4, c13, c0, #3
+; ARM-Generic-NEXT: sub     r5, sp, #40192
+; ARM-Generic-NEXT: cmp     r4, #0
+; ARM-Generic-NEXT: mvneq   r4, #61440
+; ARM-Generic-NEXT: ldreq   r4, [r4, #-15]
+; ARM-Generic-NEXT: add     r4, r4, #4
+; ARM-Generic-NEXT: ldr     r4, [r4]
+; ARM-Generic-NEXT: cmp     r4, r5
+; ARM-Generic-NEXT: blo     .LBB2_2
+
+; ARM-Generic:      mov     r4, #40192
+; ARM-Generic-NEXT: mov     r5, #0
+; ARM-Generic-NEXT: stmdb   sp!, {lr}
+; ARM-Generic-NEXT: bl      __morestack
+; ARM-Generic-NEXT: ldm     sp!, {lr}
+; ARM-Generic-NEXT: pop     {r4, r5}
+; ARM-Generic-NEXT: mov     pc, lr
+
+; ARM-Generic:      pop     {r4, r5}
+
+}
+
+define fastcc void @test_fastcc() {
+        %mem = alloca i32, i32 10
+        call void @dummy_use (i32* %mem, i32 10)
+        ret void
+
+; ARM-Generic:      test_fastcc:
+
+; ARM-Generic:      push    {r4, r5}
+; ARM-Generic-NEXT: mrc     p15, #0, r4, c13, c0, #3
+; ARM-Generic-NEXT: mov     r5, sp
+; ARM-Generic-NEXT: cmp     r4, #0
+; ARM-Generic-NEXT: mvneq   r4, #61440
+; ARM-Generic-NEXT: ldreq   r4, [r4, #-15]
+; ARM-Generic-NEXT: add     r4, r4, #4
+; ARM-Generic-NEXT: ldr     r4, [r4]
+; ARM-Generic-NEXT: cmp     r4, r5
+; ARM-Generic-NEXT: blo     .LBB3_2
+
+; ARM-Generic:      mov     r4, #44
+; ARM-Generic-NEXT: mov     r5, #0
+; ARM-Generic-NEXT: stmdb   sp!, {lr}
+; ARM-Generic-NEXT: bl      __morestack
+; ARM-Generic-NEXT: ldm     sp!, {lr}
+; ARM-Generic-NEXT: pop     {r4, r5}
+; ARM-Generic-NEXT: mov     pc, lr
+
+; ARM-Generic:      pop     {r4, r5}
+
+}
+
+define fastcc void @test_fastcc_large() {
+        %mem = alloca i32, i32 10000
+        call void @dummy_use (i32* %mem, i32 0)
+        ret void
+
+; ARM-Generic:      test_fastcc_large:
+
+; ARM-Generic:      push    {r4, r5}
+; ARM-Generic-NEXT: mrc     p15, #0, r4, c13, c0, #3
+; ARM-Generic-NEXT: sub     r5, sp, #40192
+; ARM-Generic-NEXT: cmp     r4, #0
+; ARM-Generic-NEXT: mvneq   r4, #61440
+; ARM-Generic-NEXT: ldreq   r4, [r4, #-15]
+; ARM-Generic-NEXT: add     r4, r4, #4
+; ARM-Generic-NEXT: ldr     r4, [r4]
+; ARM-Generic-NEXT: cmp     r4, r5
+; ARM-Generic-NEXT: blo     .LBB4_2
+
+; ARM-Generic:      mov     r4, #40192
+; ARM-Generic-NEXT: mov     r5, #0
+; ARM-Generic-NEXT: stmdb   sp!, {lr}
+; ARM-Generic-NEXT: bl      __morestack
+; ARM-Generic-NEXT: ldm     sp!, {lr}
+; ARM-Generic-NEXT: pop     {r4, r5}
+; ARM-Generic-NEXT: mov     pc, lr
+
+; ARM-Generic:      pop     {r4, r5}
+
+}

--- a/test/CodeGen/ARM/segmented-stacks.ll
+++ b/test/CodeGen/ARM/segmented-stacks.ll
@@ -1,7 +1,7 @@
-; RUN: llc < %s -mcpu=generic -march=arm -segmented-stacks -verify-machineinstrs | FileCheck %s -check-prefix=ARM-Generic
+; RUN: llc < %s -mtriple=arm-linux-android -segmented-stacks -verify-machineinstrs | FileCheck %s -check-prefix=ARM-Linux-Android
 
 ; We used to crash with filetype=obj
-; RUN: llc < %s -mcpu=generic -march=arm -segmented-stacks -filetype=obj
+; RUN: llc < %s -mtriple=arm-linux-android -segmented-stacks -filetype=obj
 
 
 ; Just to prevent the alloca from being optimized away
@@ -12,28 +12,28 @@ define void @test_basic() {
         call void @dummy_use (i32* %mem, i32 10)
 	ret void
 
-; ARM-Generic:      test_basic:
+; ARM-Linux-Android:      test_basic:
 
-; ARM-Generic:      push    {r4, r5}
-; ARM-Generic-NEXT: mrc     p15, #0, r4, c13, c0, #3
-; ARM-Generic-NEXT: mov     r5, sp
-; ARM-Generic-NEXT: cmp     r4, #0
-; ARM-Generic-NEXT: mvneq   r4, #61440
-; ARM-Generic-NEXT: ldreq   r4, [r4, #-15]
-; ARM-Generic-NEXT: add     r4, r4, #4
-; ARM-Generic-NEXT: ldr     r4, [r4]
-; ARM-Generic-NEXT: cmp     r4, r5
-; ARM-Generic-NEXT: blo     .LBB0_2
+; ARM-Linux-Android:      push    {r4, r5}
+; ARM-Linux-Android-NEXT: mrc     p15, #0, r4, c13, c0, #3
+; ARM-Linux-Android-NEXT: mov     r5, sp
+; ARM-Linux-Android-NEXT: cmp     r4, #0
+; ARM-Linux-Android-NEXT: mvneq   r4, #61440
+; ARM-Linux-Android-NEXT: ldreq   r4, [r4, #-15]
+; ARM-Linux-Android-NEXT: add     r4, r4, #252
+; ARM-Linux-Android-NEXT: ldr     r4, [r4]
+; ARM-Linux-Android-NEXT: cmp     r4, r5
+; ARM-Linux-Android-NEXT: blo     .LBB0_2
 
-; ARM-Generic:      mov     r4, #44
-; ARM-Generic-NEXT: mov     r5, #0
-; ARM-Generic-NEXT: stmdb   sp!, {lr}
-; ARM-Generic-NEXT: bl      __morestack
-; ARM-Generic-NEXT: ldm     sp!, {lr}
-; ARM-Generic-NEXT: pop     {r4, r5}
-; ARM-Generic-NEXT: mov     pc, lr
+; ARM-Linux-Android:      mov     r4, #48
+; ARM-Linux-Android-NEXT: mov     r5, #0
+; ARM-Linux-Android-NEXT: stmdb   sp!, {lr}
+; ARM-Linux-Android-NEXT: bl      __morestack
+; ARM-Linux-Android-NEXT: ldm     sp!, {lr}
+; ARM-Linux-Android-NEXT: pop     {r4, r5}
+; ARM-Linux-Android-NEXT: mov     pc, lr
 
-; ARM-Generic:      pop     {r4, r5}
+; ARM-Linux-Android:      pop     {r4, r5}
 
 }
 
@@ -42,28 +42,28 @@ define i32 @test_nested(i32 * nest %closure, i32 %other) {
        %result = add i32 %other, %addend
        ret i32 %result
 
-; ARM-Generic:      test_nested:
+; ARM-Linux-Android:      test_nested:
 
-; ARM-Generic:      push    {r4, r5}
-; ARM-Generic-NEXT: mrc     p15, #0, r4, c13, c0, #3
-; ARM-Generic-NEXT: mov     r5, sp
-; ARM-Generic-NEXT: cmp     r4, #0
-; ARM-Generic-NEXT: mvneq   r4, #61440
-; ARM-Generic-NEXT: ldreq   r4, [r4, #-15]
-; ARM-Generic-NEXT: add     r4, r4, #4
-; ARM-Generic-NEXT: ldr     r4, [r4]
-; ARM-Generic-NEXT: cmp     r4, r5
-; ARM-Generic-NEXT: blo     .LBB1_2
+; ARM-Linux-Android:      push    {r4, r5}
+; ARM-Linux-Android-NEXT: mrc     p15, #0, r4, c13, c0, #3
+; ARM-Linux-Android-NEXT: mov     r5, sp
+; ARM-Linux-Android-NEXT: cmp     r4, #0
+; ARM-Linux-Android-NEXT: mvneq   r4, #61440
+; ARM-Linux-Android-NEXT: ldreq   r4, [r4, #-15]
+; ARM-Linux-Android-NEXT: add     r4, r4, #252
+; ARM-Linux-Android-NEXT: ldr     r4, [r4]
+; ARM-Linux-Android-NEXT: cmp     r4, r5
+; ARM-Linux-Android-NEXT: blo     .LBB1_2
 
-; ARM-Generic:      mov     r4, #0
-; ARM-Generic-NEXT: mov     r5, #0
-; ARM-Generic-NEXT: stmdb   sp!, {lr}
-; ARM-Generic-NEXT: bl      __morestack
-; ARM-Generic-NEXT: ldm     sp!, {lr}
-; ARM-Generic-NEXT: pop     {r4, r5}
-; ARM-Generic-NEXT: mov     pc, lr
+; ARM-Linux-Android:      mov     r4, #0
+; ARM-Linux-Android-NEXT: mov     r5, #0
+; ARM-Linux-Android-NEXT: stmdb   sp!, {lr}
+; ARM-Linux-Android-NEXT: bl      __morestack
+; ARM-Linux-Android-NEXT: ldm     sp!, {lr}
+; ARM-Linux-Android-NEXT: pop     {r4, r5}
+; ARM-Linux-Android-NEXT: mov     pc, lr
 
-; ARM-Generic:      pop     {r4, r5}
+; ARM-Linux-Android:      pop     {r4, r5}
 
 }
 
@@ -72,28 +72,28 @@ define void @test_large() {
         call void @dummy_use (i32* %mem, i32 0)
         ret void
 
-; ARM-Generic:      test_large:
+; ARM-Linux-Android:      test_large:
 
-; ARM-Generic:      push    {r4, r5}
-; ARM-Generic-NEXT: mrc     p15, #0, r4, c13, c0, #3
-; ARM-Generic-NEXT: sub     r5, sp, #40192
-; ARM-Generic-NEXT: cmp     r4, #0
-; ARM-Generic-NEXT: mvneq   r4, #61440
-; ARM-Generic-NEXT: ldreq   r4, [r4, #-15]
-; ARM-Generic-NEXT: add     r4, r4, #4
-; ARM-Generic-NEXT: ldr     r4, [r4]
-; ARM-Generic-NEXT: cmp     r4, r5
-; ARM-Generic-NEXT: blo     .LBB2_2
+; ARM-Linux-Android:      push    {r4, r5}
+; ARM-Linux-Android-NEXT: mrc     p15, #0, r4, c13, c0, #3
+; ARM-Linux-Android-NEXT: sub     r5, sp, #40192
+; ARM-Linux-Android-NEXT: cmp     r4, #0
+; ARM-Linux-Android-NEXT: mvneq   r4, #61440
+; ARM-Linux-Android-NEXT: ldreq   r4, [r4, #-15]
+; ARM-Linux-Android-NEXT: add     r4, r4, #252
+; ARM-Linux-Android-NEXT: ldr     r4, [r4]
+; ARM-Linux-Android-NEXT: cmp     r4, r5
+; ARM-Linux-Android-NEXT: blo     .LBB2_2
 
-; ARM-Generic:      mov     r4, #40192
-; ARM-Generic-NEXT: mov     r5, #0
-; ARM-Generic-NEXT: stmdb   sp!, {lr}
-; ARM-Generic-NEXT: bl      __morestack
-; ARM-Generic-NEXT: ldm     sp!, {lr}
-; ARM-Generic-NEXT: pop     {r4, r5}
-; ARM-Generic-NEXT: mov     pc, lr
+; ARM-Linux-Android:      mov     r4, #40192
+; ARM-Linux-Android-NEXT: mov     r5, #0
+; ARM-Linux-Android-NEXT: stmdb   sp!, {lr}
+; ARM-Linux-Android-NEXT: bl      __morestack
+; ARM-Linux-Android-NEXT: ldm     sp!, {lr}
+; ARM-Linux-Android-NEXT: pop     {r4, r5}
+; ARM-Linux-Android-NEXT: mov     pc, lr
 
-; ARM-Generic:      pop     {r4, r5}
+; ARM-Linux-Android:      pop     {r4, r5}
 
 }
 
@@ -102,28 +102,28 @@ define fastcc void @test_fastcc() {
         call void @dummy_use (i32* %mem, i32 10)
         ret void
 
-; ARM-Generic:      test_fastcc:
+; ARM-Linux-Android:      test_fastcc:
 
-; ARM-Generic:      push    {r4, r5}
-; ARM-Generic-NEXT: mrc     p15, #0, r4, c13, c0, #3
-; ARM-Generic-NEXT: mov     r5, sp
-; ARM-Generic-NEXT: cmp     r4, #0
-; ARM-Generic-NEXT: mvneq   r4, #61440
-; ARM-Generic-NEXT: ldreq   r4, [r4, #-15]
-; ARM-Generic-NEXT: add     r4, r4, #4
-; ARM-Generic-NEXT: ldr     r4, [r4]
-; ARM-Generic-NEXT: cmp     r4, r5
-; ARM-Generic-NEXT: blo     .LBB3_2
+; ARM-Linux-Android:      push    {r4, r5}
+; ARM-Linux-Android-NEXT: mrc     p15, #0, r4, c13, c0, #3
+; ARM-Linux-Android-NEXT: mov     r5, sp
+; ARM-Linux-Android-NEXT: cmp     r4, #0
+; ARM-Linux-Android-NEXT: mvneq   r4, #61440
+; ARM-Linux-Android-NEXT: ldreq   r4, [r4, #-15]
+; ARM-Linux-Android-NEXT: add     r4, r4, #252
+; ARM-Linux-Android-NEXT: ldr     r4, [r4]
+; ARM-Linux-Android-NEXT: cmp     r4, r5
+; ARM-Linux-Android-NEXT: blo     .LBB3_2
 
-; ARM-Generic:      mov     r4, #44
-; ARM-Generic-NEXT: mov     r5, #0
-; ARM-Generic-NEXT: stmdb   sp!, {lr}
-; ARM-Generic-NEXT: bl      __morestack
-; ARM-Generic-NEXT: ldm     sp!, {lr}
-; ARM-Generic-NEXT: pop     {r4, r5}
-; ARM-Generic-NEXT: mov     pc, lr
+; ARM-Linux-Android:      mov     r4, #48
+; ARM-Linux-Android-NEXT: mov     r5, #0
+; ARM-Linux-Android-NEXT: stmdb   sp!, {lr}
+; ARM-Linux-Android-NEXT: bl      __morestack
+; ARM-Linux-Android-NEXT: ldm     sp!, {lr}
+; ARM-Linux-Android-NEXT: pop     {r4, r5}
+; ARM-Linux-Android-NEXT: mov     pc, lr
 
-; ARM-Generic:      pop     {r4, r5}
+; ARM-Linux-Android:      pop     {r4, r5}
 
 }
 
@@ -132,27 +132,27 @@ define fastcc void @test_fastcc_large() {
         call void @dummy_use (i32* %mem, i32 0)
         ret void
 
-; ARM-Generic:      test_fastcc_large:
+; ARM-Linux-Android:      test_fastcc_large:
 
-; ARM-Generic:      push    {r4, r5}
-; ARM-Generic-NEXT: mrc     p15, #0, r4, c13, c0, #3
-; ARM-Generic-NEXT: sub     r5, sp, #40192
-; ARM-Generic-NEXT: cmp     r4, #0
-; ARM-Generic-NEXT: mvneq   r4, #61440
-; ARM-Generic-NEXT: ldreq   r4, [r4, #-15]
-; ARM-Generic-NEXT: add     r4, r4, #4
-; ARM-Generic-NEXT: ldr     r4, [r4]
-; ARM-Generic-NEXT: cmp     r4, r5
-; ARM-Generic-NEXT: blo     .LBB4_2
+; ARM-Linux-Android:      push    {r4, r5}
+; ARM-Linux-Android-NEXT: mrc     p15, #0, r4, c13, c0, #3
+; ARM-Linux-Android-NEXT: sub     r5, sp, #40192
+; ARM-Linux-Android-NEXT: cmp     r4, #0
+; ARM-Linux-Android-NEXT: mvneq   r4, #61440
+; ARM-Linux-Android-NEXT: ldreq   r4, [r4, #-15]
+; ARM-Linux-Android-NEXT: add     r4, r4, #252
+; ARM-Linux-Android-NEXT: ldr     r4, [r4]
+; ARM-Linux-Android-NEXT: cmp     r4, r5
+; ARM-Linux-Android-NEXT: blo     .LBB4_2
 
-; ARM-Generic:      mov     r4, #40192
-; ARM-Generic-NEXT: mov     r5, #0
-; ARM-Generic-NEXT: stmdb   sp!, {lr}
-; ARM-Generic-NEXT: bl      __morestack
-; ARM-Generic-NEXT: ldm     sp!, {lr}
-; ARM-Generic-NEXT: pop     {r4, r5}
-; ARM-Generic-NEXT: mov     pc, lr
+; ARM-Linux-Android:      mov     r4, #40192
+; ARM-Linux-Android-NEXT: mov     r5, #0
+; ARM-Linux-Android-NEXT: stmdb   sp!, {lr}
+; ARM-Linux-Android-NEXT: bl      __morestack
+; ARM-Linux-Android-NEXT: ldm     sp!, {lr}
+; ARM-Linux-Android-NEXT: pop     {r4, r5}
+; ARM-Linux-Android-NEXT: mov     pc, lr
 
-; ARM-Generic:      pop     {r4, r5}
+; ARM-Linux-Android:      pop     {r4, r5}
 
 }

--- a/test/CodeGen/Thumb/segmented-stacks-dynamic.ll
+++ b/test/CodeGen/Thumb/segmented-stacks-dynamic.ll
@@ -1,5 +1,5 @@
-; RUN: llc < %s -mcpu=generic -mtriple=thumb-linux-android -segmented-stacks -verify-machineinstrs | FileCheck %s -check-prefix=Thumb-Linux-Android
-; RUN: llc < %s -mcpu=generic -mtriple=thumb-linux-android -segmented-stacks -filetype=obj
+; RUN: llc < %s -mcpu=generic -march=thumb -segmented-stacks -verify-machineinstrs | FileCheck %s -check-prefix=Thumb-Generic
+; RUN: llc < %s -mcpu=generic -march=thumb -segmented-stacks -filetype=obj
 
 ; Just to prevent the alloca from being optimized away
 declare void @dummy_use(i32*, i32)
@@ -18,24 +18,24 @@ false:
         %retvalue = call i32 @test_basic(i32 %newlen)
         ret i32 %retvalue
 
-; Thumb-Linux-Android:      test_basic:
+; Thumb-Generic:      test_basic:
 
-; Thumb-Linux-Android:      push {r4, r5}
-; Thumb-Linux-Android-NEXT: mov	r5, sp
-; Thumb-Linux-Android-NEXT: ldr r4, .LCPI0_0
-; Thumb-Linux-Android-NEXT: ldr r4, [r4]
-; Thumb-Linux-Android-NEXT: cmp	r4, r5
-; Thumb-Linux-Android-NEXT: blo	.LBB0_2
+; Thumb-Generic:      push {r4, r5}
+; Thumb-Generic-NEXT: mov	r5, sp
+; Thumb-Generic-NEXT: ldr r4, .LCPI0_0
+; Thumb-Generic-NEXT: ldr r4, [r4]
+; Thumb-Generic-NEXT: cmp	r4, r5
+; Thumb-Generic-NEXT: blo	.LBB0_2
 
-; Thumb-Linux-Android:      mov r4, #16
-; Thumb-Linux-Android-NEXT: mov r5, #0
-; Thumb-Linux-Android-NEXT: push {lr}
-; Thumb-Linux-Android-NEXT: bl	__morestack
-; Thumb-Linux-Android-NEXT: pop {r4}
-; Thumb-Linux-Android-NEXT: mov lr, r4
-; Thumb-Linux-Android-NEXT: pop	{r4, r5}
-; Thumb-Linux-Android-NEXT: mov	pc, lr
+; Thumb-Generic:      mov r4, #20
+; Thumb-Generic-NEXT: mov r5, #0
+; Thumb-Generic-NEXT: push {lr}
+; Thumb-Generic-NEXT: bl	__morestack
+; Thumb-Generic-NEXT: pop {r4}
+; Thumb-Generic-NEXT: mov lr, r4
+; Thumb-Generic-NEXT: pop	{r4, r5}
+; Thumb-Generic-NEXT: mov	pc, lr
 
-; Thumb-Linux-Android:      pop	{r4, r5}
+; Thumb-Generic:      pop	{r4, r5}
 
 }

--- a/test/CodeGen/Thumb/segmented-stacks-dynamic.ll
+++ b/test/CodeGen/Thumb/segmented-stacks-dynamic.ll
@@ -1,5 +1,5 @@
-; RUN: llc < %s -mcpu=generic -march=thumb -segmented-stacks -verify-machineinstrs | FileCheck %s -check-prefix=Thumb-Generic
-; RUN: llc < %s -mcpu=generic -march=thumb -segmented-stacks -filetype=obj
+; RUN: llc < %s -mtriple=thumb-unknown-unknown -segmented-stacks -verify-machineinstrs | FileCheck %s -check-prefix=Thumb-Generic
+; RUN: llc < %s -mtriple=thumb-unknown-unknown -segmented-stacks -filetype=obj
 
 ; Just to prevent the alloca from being optimized away
 declare void @dummy_use(i32*, i32)

--- a/test/CodeGen/Thumb/segmented-stacks.ll
+++ b/test/CodeGen/Thumb/segmented-stacks.ll
@@ -1,7 +1,7 @@
-; RUN: llc < %s -mcpu=generic -march=thumb -segmented-stacks -verify-machineinstrs | FileCheck %s -check-prefix=Thumb-Generic
+; RUN: llc < %s -mtriple=thumb-unknown-unknown -segmented-stacks -verify-machineinstrs | FileCheck %s -check-prefix=Thumb-Generic
 
 ; We used to crash with filetype=obj
-; RUN: llc < %s -mcpu=generic -march=thumb -segmented-stacks -filetype=obj
+; RUN: llc < %s -mtriple=thumb-unknown-unknown -segmented-stacks -filetype=obj
 
 
 ; Just to prevent the alloca from being optimized away

--- a/test/CodeGen/Thumb/segmented-stacks.ll
+++ b/test/CodeGen/Thumb/segmented-stacks.ll
@@ -1,7 +1,7 @@
-; RUN: llc < %s -mcpu=generic -mtriple=thumb-linux-android -segmented-stacks -verify-machineinstrs | FileCheck %s -check-prefix=Thumb-Linux-Android
+; RUN: llc < %s -mcpu=generic -march=thumb -segmented-stacks -verify-machineinstrs | FileCheck %s -check-prefix=Thumb-Generic
 
 ; We used to crash with filetype=obj
-; RUN: llc < %s -mcpu=generic -mtriple=thumb-linux-android -segmented-stacks -filetype=obj
+; RUN: llc < %s -mcpu=generic -march=thumb -segmented-stacks -filetype=obj
 
 
 ; Just to prevent the alloca from being optimized away
@@ -12,25 +12,25 @@ define void @test_basic() {
         call void @dummy_use (i32* %mem, i32 10)
 	ret void
 
-; Thumb-Linux-Android:      test_basic:
+; Thumb-Generic:      test_basic:
 
-; Thumb-Linux-Android:      push    {r4, r5}
-; Thumb-Linux-Android-NEXT: mov     r5, sp
-; Thumb-Linux-Android-NEXT: ldr     r4, .LCPI0_0
-; Thumb-Linux-Android-NEXT: ldr     r4, [r4]
-; Thumb-Linux-Android-NEXT: cmp     r4, r5
-; Thumb-Linux-Android-NEXT: blo     .LBB0_2
+; Thumb-Generic:      push    {r4, r5}
+; Thumb-Generic-NEXT: mov     r5, sp
+; Thumb-Generic-NEXT: ldr     r4, .LCPI0_0
+; Thumb-Generic-NEXT: ldr     r4, [r4]
+; Thumb-Generic-NEXT: cmp     r4, r5
+; Thumb-Generic-NEXT: blo     .LBB0_2
 
-; Thumb-Linux-Android:      mov     r4, #48
-; Thumb-Linux-Android-NEXT: mov     r5, #0
-; Thumb-Linux-Android-NEXT: push    {lr}
-; Thumb-Linux-Android-NEXT: bl      __morestack
-; Thumb-Linux-Android-NEXT: pop     {r4}
-; Thumb-Linux-Android-NEXT: mov     lr, r4
-; Thumb-Linux-Android-NEXT: pop     {r4, r5}
-; Thumb-Linux-Android-NEXT: mov     pc, lr
+; Thumb-Generic:      mov     r4, #44
+; Thumb-Generic-NEXT: mov     r5, #0
+; Thumb-Generic-NEXT: push    {lr}
+; Thumb-Generic-NEXT: bl      __morestack
+; Thumb-Generic-NEXT: pop     {r4}
+; Thumb-Generic-NEXT: mov     lr, r4
+; Thumb-Generic-NEXT: pop     {r4, r5}
+; Thumb-Generic-NEXT: mov     pc, lr
 
-; Thumb-Linux-Android:      pop     {r4, r5}
+; Thumb-Generic:      pop     {r4, r5}
 
 }
 
@@ -39,25 +39,25 @@ define i32 @test_nested(i32 * nest %closure, i32 %other) {
        %result = add i32 %other, %addend
        ret i32 %result
 
-; Thumb-Linux-Android:      test_nested:
+; Thumb-Generic:      test_nested:
 
-; Thumb-Linux-Android:      push    {r4, r5}
-; Thumb-Linux-Android-NEXT: mov     r5, sp
-; Thumb-Linux-Android-NEXT: ldr     r4, .LCPI1_0
-; Thumb-Linux-Android-NEXT: ldr     r4, [r4]
-; Thumb-Linux-Android-NEXT: cmp     r4, r5
-; Thumb-Linux-Android-NEXT: blo     .LBB1_2
+; Thumb-Generic:      push    {r4, r5}
+; Thumb-Generic-NEXT: mov     r5, sp
+; Thumb-Generic-NEXT: ldr     r4, .LCPI1_0
+; Thumb-Generic-NEXT: ldr     r4, [r4]
+; Thumb-Generic-NEXT: cmp     r4, r5
+; Thumb-Generic-NEXT: blo     .LBB1_2
 
-; Thumb-Linux-Android:      mov     r4, #0
-; Thumb-Linux-Android-NEXT: mov     r5, #0
-; Thumb-Linux-Android-NEXT: push    {lr}
-; Thumb-Linux-Android-NEXT: bl      __morestack
-; Thumb-Linux-Android-NEXT: pop     {r4}
-; Thumb-Linux-Android-NEXT: mov     lr, r4
-; Thumb-Linux-Android-NEXT: pop     {r4, r5}
-; Thumb-Linux-Android-NEXT: mov     pc, lr
+; Thumb-Generic:      mov     r4, #0
+; Thumb-Generic-NEXT: mov     r5, #0
+; Thumb-Generic-NEXT: push    {lr}
+; Thumb-Generic-NEXT: bl      __morestack
+; Thumb-Generic-NEXT: pop     {r4}
+; Thumb-Generic-NEXT: mov     lr, r4
+; Thumb-Generic-NEXT: pop     {r4, r5}
+; Thumb-Generic-NEXT: mov     pc, lr
 
-; Thumb-Linux-Android:      pop     {r4, r5}
+; Thumb-Generic:      pop     {r4, r5}
 
 }
 
@@ -66,26 +66,26 @@ define void @test_large() {
         call void @dummy_use (i32* %mem, i32 0)
         ret void
 
-; Thumb-Linux-Android:      test_large:
+; Thumb-Generic:      test_large:
 
-; Thumb-Linux-Android:      push    {r4, r5}
-; Thumb-Linux-Android-NEXT: mov     r5, sp
-; Thumb-Linux-Android-NEXT: sub     r5, #40192
-; Thumb-Linux-Android-NEXT: ldr     r4, .LCPI2_2
-; Thumb-Linux-Android-NEXT: ldr     r4, [r4]
-; Thumb-Linux-Android-NEXT: cmp     r4, r5
-; Thumb-Linux-Android-NEXT: blo     .LBB2_2
+; Thumb-Generic:      push    {r4, r5}
+; Thumb-Generic-NEXT: mov     r5, sp
+; Thumb-Generic-NEXT: sub     r5, #40192
+; Thumb-Generic-NEXT: ldr     r4, .LCPI2_2
+; Thumb-Generic-NEXT: ldr     r4, [r4]
+; Thumb-Generic-NEXT: cmp     r4, r5
+; Thumb-Generic-NEXT: blo     .LBB2_2
 
-; Thumb-Linux-Android:      mov     r4, #40192
-; Thumb-Linux-Android-NEXT: mov     r5, #0
-; Thumb-Linux-Android-NEXT: push    {lr}
-; Thumb-Linux-Android-NEXT: bl      __morestack
-; Thumb-Linux-Android-NEXT: pop     {r4}
-; Thumb-Linux-Android-NEXT: mov     lr, r4
-; Thumb-Linux-Android-NEXT: pop     {r4, r5}
-; Thumb-Linux-Android-NEXT: mov     pc, lr
+; Thumb-Generic:      mov     r4, #40192
+; Thumb-Generic-NEXT: mov     r5, #0
+; Thumb-Generic-NEXT: push    {lr}
+; Thumb-Generic-NEXT: bl      __morestack
+; Thumb-Generic-NEXT: pop     {r4}
+; Thumb-Generic-NEXT: mov     lr, r4
+; Thumb-Generic-NEXT: pop     {r4, r5}
+; Thumb-Generic-NEXT: mov     pc, lr
 
-; Thumb-Linux-Android:      pop     {r4, r5}
+; Thumb-Generic:      pop     {r4, r5}
 
 }
 
@@ -94,25 +94,25 @@ define fastcc void @test_fastcc() {
         call void @dummy_use (i32* %mem, i32 10)
         ret void
 
-; Thumb-Linux-Android:      test_fastcc:
+; Thumb-Generic:      test_fastcc:
 
-; Thumb-Linux-Android:      push    {r4, r5}
-; Thumb-Linux-Android-NEXT: mov     r5, sp
-; Thumb-Linux-Android-NEXT: ldr     r4, .LCPI3_0
-; Thumb-Linux-Android-NEXT: ldr     r4, [r4]
-; Thumb-Linux-Android-NEXT: cmp     r4, r5
-; Thumb-Linux-Android-NEXT: blo     .LBB3_2
+; Thumb-Generic:      push    {r4, r5}
+; Thumb-Generic-NEXT: mov     r5, sp
+; Thumb-Generic-NEXT: ldr     r4, .LCPI3_0
+; Thumb-Generic-NEXT: ldr     r4, [r4]
+; Thumb-Generic-NEXT: cmp     r4, r5
+; Thumb-Generic-NEXT: blo     .LBB3_2
 
-; Thumb-Linux-Android:      mov     r4, #48
-; Thumb-Linux-Android-NEXT: mov     r5, #0
-; Thumb-Linux-Android-NEXT: push    {lr}
-; Thumb-Linux-Android-NEXT: bl      __morestack
-; Thumb-Linux-Android-NEXT: pop     {r4}
-; Thumb-Linux-Android-NEXT: mov     lr, r4
-; Thumb-Linux-Android-NEXT: pop     {r4, r5}
-; Thumb-Linux-Android-NEXT: mov     pc, lr
+; Thumb-Generic:      mov     r4, #44
+; Thumb-Generic-NEXT: mov     r5, #0
+; Thumb-Generic-NEXT: push    {lr}
+; Thumb-Generic-NEXT: bl      __morestack
+; Thumb-Generic-NEXT: pop     {r4}
+; Thumb-Generic-NEXT: mov     lr, r4
+; Thumb-Generic-NEXT: pop     {r4, r5}
+; Thumb-Generic-NEXT: mov     pc, lr
 
-; Thumb-Linux-Android:      pop     {r4, r5}
+; Thumb-Generic:      pop     {r4, r5}
 
 }
 
@@ -121,25 +121,25 @@ define fastcc void @test_fastcc_large() {
         call void @dummy_use (i32* %mem, i32 0)
         ret void
 
-; Thumb-Linux-Android:      test_fastcc_large:
+; Thumb-Generic:      test_fastcc_large:
 
-; Thumb-Linux-Android:      push    {r4, r5}
-; Thumb-Linux-Android-NEXT: mov     r5, sp
-; Thumb-Linux-Android-NEXT: sub     r5, #40192
-; Thumb-Linux-Android-NEXT: ldr     r4, .LCPI4_2
-; Thumb-Linux-Android-NEXT: ldr     r4, [r4]
-; Thumb-Linux-Android-NEXT: cmp     r4, r5
-; Thumb-Linux-Android-NEXT: blo     .LBB4_2
+; Thumb-Generic:      push    {r4, r5}
+; Thumb-Generic-NEXT: mov     r5, sp
+; Thumb-Generic-NEXT: sub     r5, #40192
+; Thumb-Generic-NEXT: ldr     r4, .LCPI4_2
+; Thumb-Generic-NEXT: ldr     r4, [r4]
+; Thumb-Generic-NEXT: cmp     r4, r5
+; Thumb-Generic-NEXT: blo     .LBB4_2
 
-; Thumb-Linux-Android:      mov     r4, #40192
-; Thumb-Linux-Android-NEXT: mov     r5, #0
-; Thumb-Linux-Android-NEXT: push    {lr}
-; Thumb-Linux-Android-NEXT: bl      __morestack
-; Thumb-Linux-Android-NEXT: pop     {r4}
-; Thumb-Linux-Android-NEXT: mov     lr, r4
-; Thumb-Linux-Android-NEXT: pop     {r4, r5}
-; Thumb-Linux-Android-NEXT: mov     pc, lr
+; Thumb-Generic:      mov     r4, #40192
+; Thumb-Generic-NEXT: mov     r5, #0
+; Thumb-Generic-NEXT: push    {lr}
+; Thumb-Generic-NEXT: bl      __morestack
+; Thumb-Generic-NEXT: pop     {r4}
+; Thumb-Generic-NEXT: mov     lr, r4
+; Thumb-Generic-NEXT: pop     {r4, r5}
+; Thumb-Generic-NEXT: mov     pc, lr
 
-; Thumb-Linux-Android:      pop     {r4, r5}
+; Thumb-Generic:      pop     {r4, r5}
 
 }


### PR DESCRIPTION
Add LLVM segmented stack tests for ARM platform.
Update Thumb tests to use generic target.
