### PR TITLE
Improve the NullCheckElimination pass

### DIFF
--- a/lib/Transforms/Scalar/NullCheckElimination.cpp
+++ b/lib/Transforms/Scalar/NullCheckElimination.cpp
@@ -34,35 +34,84 @@ namespace {
   private:
     static const unsigned kPhiLimit = 16;
     typedef SmallPtrSet<PHINode*, kPhiLimit> SmallPhiSet;
-    enum NullCheckResult {
-	NotNullCheck,
-	NullCheckEq,
-	NullCheckNe,
+
+    enum CmpKind {
+      /// A null check of an unconditionally nonnull-or-poison value.
+      NullCheckDefiniteCmp,
+
+      /// A null check of the phi representing a nontrivial inbounds recurrence,
+      /// which is not known to be unconditionally nonnull-or-poison.
+      NullCheckRecurrenceCmp,
+
+      /// A comparison of the phi representing a nontrivial inbounds recurrence
+      /// with an inbounds GEP derived from the base of the recurrence, which
+      /// will typically represent a bound on the recurrence.
+      RecurrencePhiBoundCmp,
     };
 
-    bool isNonNullOrPoisonPhi(SmallPhiSet *VisitedPhis, PHINode*);
+    enum CmpPred {
+      CmpEq,
+      CmpNe,
+    };
 
-    NullCheckResult isCmpNullCheck(ICmpInst*);
-    std::pair<Use*, NullCheckResult> findNullCheck(Use*);
+    struct CmpDesc {
+      CmpDesc(CmpKind k, CmpPred p, Use *u, Value *v)
+        : kind(k), pred(p), use(u), ptrValue(v) { }
+
+      CmpKind kind;
+      CmpPred pred;
+      Use *use;
+      Value *ptrValue;
+    };
+
+    typedef SmallVector<CmpDesc, 4> CmpDescVec;
+
+    bool isNonNullOrPoisonPhi(SmallPhiSet *VisitedPhis, PHINode*);
+    Value *isNontrivialInBoundsRecurrence(PHINode*);
+
+    bool classifyCmp(CmpDescVec*, Use*);
+    bool findRelevantCmps(CmpDescVec*, Use*);
 
     bool blockContainsLoadDerivedFrom(BasicBlock*, Value*);
 
+    /// Tracks values that are unconditionally nonnull-or-poison by definition,
+    /// but not values that are known nonnull-or-poison in a given context by
+    /// their uses, e.g. in recurrences.
     DenseSet<Value*> NonNullOrPoisonValues;
+
+    /// Tracks values that are bases of nontrivial inbounds recurrences.
+    DenseSet<Value*> InBoundsRecurrenceBases;
+
+    /// Maps phis that correspond to nontrivial inbounds recurrences to their
+    /// base values.
+    DenseMap<Value*, Value*> InBoundsRecurrenceBaseMap;
   };
 }
 
 char NullCheckElimination::ID = 0;
 INITIALIZE_PASS_BEGIN(NullCheckElimination,
-		      "null-check-elimination",
-		      "Null Check Elimination",
-		      false, false)
+                      "null-check-elimination",
+                      "Null Check Elimination",
+                      false, false)
 INITIALIZE_PASS_END(NullCheckElimination,
-		    "null-check-elimination",
-		    "Null Check Elimination",
-		    false, false)
+                    "null-check-elimination",
+                    "Null Check Elimination",
+                    false, false)
 
 FunctionPass *llvm::createNullCheckEliminationPass() {
   return new NullCheckElimination();
+}
+
+static GetElementPtrInst *castToInBoundsGEP(Value *V) {
+  auto *GEP = dyn_cast<GetElementPtrInst>(V);
+  if (!GEP || !GEP->isInBounds())
+    return nullptr;
+  return GEP;
+}
+
+static bool isZeroConstant(Value *V) {
+  auto *C = dyn_cast<Constant>(V);
+  return C && C->isZeroValue();
 }
 
 bool NullCheckElimination::runOnFunction(Function &F) {
@@ -71,38 +120,30 @@ bool NullCheckElimination::runOnFunction(Function &F) {
 
   bool Changed = false;
 
-  // Collect argumetns with the `nonnull` attribute.
+  // Collect arguments with the `nonnull` attribute.
   for (auto &Arg : F.args()) {
     if (Arg.hasNonNullAttr())
       NonNullOrPoisonValues.insert(&Arg);
   }
 
-  // Collect instructions that definitely produce nonnull-or-poison values.
-  // At the moment, this is restricted to inbounds GEPs. It would be slightly
-  // more difficult to include uses of values dominated by a null check, since
-  // then we would have to consider uses instead of mere values.
+  // Collect instructions that definitely produce nonnull-or-poison values. At
+  // the moment, this is restricted to inbounds GEPs, and phis that are derived
+  // entirely from nonnull-or-poison-values (including other phis that are
+  // themselves derived from the same).
   for (auto &BB : F) {
     for (auto &I : BB) {
-      if (auto *GEP = dyn_cast<GetElementPtrInst>(&I)) {
-	if (GEP->isInBounds()) {
-	  NonNullOrPoisonValues.insert(GEP);
-	}
+      if (auto *GEP = castToInBoundsGEP(&I)) {
+        NonNullOrPoisonValues.insert(GEP);
+      } else if (auto *PN = dyn_cast<PHINode>(&I)) {
+        SmallPhiSet VisitedPHIs;
+        if (isNonNullOrPoisonPhi(&VisitedPHIs, PN))
+          NonNullOrPoisonValues.insert(PN);
+
+        if (auto *BaseV = isNontrivialInBoundsRecurrence(PN)) {
+          InBoundsRecurrenceBases.insert(BaseV);
+          InBoundsRecurrenceBaseMap[PN] = BaseV;
+        }
       }
-    }
-  }
-
-  // Find phis that are derived entirely from nonnull-or-poison values,
-  // including other phis that are themselves derived entirely from these
-  // values.
-  for (auto &BB : F) {
-    for (auto &I : BB) {
-      auto *PN = dyn_cast<PHINode>(&I);
-      if (!PN)
-	break;
-
-      SmallPhiSet VisitedPHIs;
-      if (isNonNullOrPoisonPhi(&VisitedPHIs, PN))
-	NonNullOrPoisonValues.insert(PN);
     }
   }
 
@@ -114,49 +155,75 @@ bool NullCheckElimination::runOnFunction(Function &F) {
       continue;
 
     // The first operand of a conditional branch is the condition.
-    auto result = findNullCheck(&BI->getOperandUse(0));
-    if (!result.first)
+    CmpDescVec Cmps;
+    if (!findRelevantCmps(&Cmps, &BI->getOperandUse(0)))
       continue;
-    assert((result.second == NullCheckEq || result.second == NullCheckNe) &&
-	   "valid null check kind expected if ICmpInst was found");
 
-    BasicBlock *NonNullBB;
-    if (result.second == NullCheckEq) {
-      // If the comparison instruction is checking for equaliity with null,
-      // then the pointer is nonnull on the `false` branch.
-      NonNullBB = BI->getSuccessor(1);
-    } else {
-      // Otherwise, if the comparison instruction is checking for inequality
-      // with null, the pointer is nonnull on the `true` branch.
-      NonNullBB = BI->getSuccessor(0);
-    }
+    for (auto &Cmp : Cmps) {
+      // We are only tracking comparisons of inbounds recurrence phis with their
+      // bounds so that we can eliminate null checks based on them, which are of
+      // kind NullCheckRecurrenceCmp. We can't use a lone RecurrencePhiBoundCmp
+      // to perform any optimizations.
+      if (Cmp.kind == RecurrencePhiBoundCmp)
+        continue;
 
-    Use *U = result.first;
-    ICmpInst *CI = cast<ICmpInst>(U->get());
-    unsigned nonConstantIndex;
-    if (isa<Constant>(CI->getOperand(0)))
-      nonConstantIndex = 1;
-    else
-      nonConstantIndex = 0;
+      if (Cmp.kind == NullCheckRecurrenceCmp) {
+        // Look for a matching RecurrencePhiBoundCmp. If one exists, then we can
+        // be sure that this branch condition depends on the recurrence. Since
+        // both the bounds and the recurrence successor value are inbounds, and
+        // they are both derived from the base, the base being null would imply
+        // that the bounds and recurrence successor values are poison.
+        bool FoundMatchingCmp = false;
+        for (auto &OtherCmp : Cmps) {
+          if (OtherCmp.kind == RecurrencePhiBoundCmp &&
+              OtherCmp.ptrValue == Cmp.ptrValue) {
+            FoundMatchingCmp = true;
+            break;
+          }
+        }
+        if (!FoundMatchingCmp)
+          continue;
+      }
 
-    // Due to the semantics of poison values in LLVM, we have to check that
-    // there is actually some externally visible side effect that is dependent
-    // on the poison value. Since poison values are otherwise treated as undef,
-    // and a load of undef is undefined behavior (which is externally visible),
-    // it suffices to look for a load of the nonnull-or-poison value.
-    //
-    // This could be extended to any block control-dependent on this branch of
-    // the null check, it's unclear if that will actually catch more cases in
-    // real code.
-    Value *PtrV = CI->getOperand(nonConstantIndex);
-    if (blockContainsLoadDerivedFrom(NonNullBB, PtrV)) {
-      Type *BoolTy = CI->getType();
-      Value *NewV = ConstantInt::get(BoolTy, result.second == NullCheckNe);
-      U->set(NewV);
+      BasicBlock *NonNullBB;
+      if (Cmp.pred == CmpEq) {
+        // If the comparison instruction is checking for equality with null then
+        // the pointer is nonnull on the `false` branch.
+        NonNullBB = BI->getSuccessor(1);
+      } else {
+        // Otherwise, if the comparison instruction is checking for inequality
+        // with null, the pointer is nonnull on the `true` branch.
+        NonNullBB = BI->getSuccessor(0);
+      }
+
+      // This is a crude approximation of control dependence: if the branch
+      // target has a single predecessor edge, then it must be control-
+      // dependent on the branch.
+      if (!NonNullBB->getSinglePredecessor())
+        continue;
+
+      // Due to the semantics of poison values in LLVM, we have to check that
+      // there is actually some externally visible side effect that is dependent
+      // on the poison value. Since poison values are otherwise treated as
+      // undef, and a load of undef is undefined behavior (which is externally
+      // visible), it suffices to look for a load of the nonnull-or-poison
+      // value.
+      //
+      // This could be extended to any block control-dependent on this branch of
+      // the null check, it's unclear if that will actually catch more cases in
+      // real code.
+      if (blockContainsLoadDerivedFrom(NonNullBB, Cmp.ptrValue)) {
+        Type *BoolTy = Type::getInt1Ty(F.getContext());
+        Value *NewV = ConstantInt::get(BoolTy, Cmp.pred == CmpNe);
+        Cmp.use->set(NewV);
+        Changed = true;
+      }
     }
   }
 
   NonNullOrPoisonValues.clear();
+  InBoundsRecurrenceBases.clear();
+  InBoundsRecurrenceBaseMap.clear();
 
   return Changed;
 }
@@ -164,9 +231,12 @@ bool NullCheckElimination::runOnFunction(Function &F) {
 /// Checks whether a phi is derived from known nonnnull-or-poison values,
 /// including other phis that are derived from the same. May return `false`
 /// conservatively in some cases, e.g. if exploring a large cycle of phis.
+///
+/// This function may also insert any inbounds GEPs that it finds into
+/// NonNullOrPoisonValues.
 bool
 NullCheckElimination::isNonNullOrPoisonPhi(SmallPhiSet *VisitedPhis,
-					   PHINode *PN) {
+                                           PHINode *PN) {
   // If we've already seen this phi, return `true`, even though it may not be
   // nonnull, since some other operand in a cycle of phis may invalidate the
   // optimistic assumption that the entire cycle is nonnull, including this phi.
@@ -183,9 +253,11 @@ NullCheckElimination::isNonNullOrPoisonPhi(SmallPhiSet *VisitedPhis,
     Value *SrcValue = PN->getOperand(i);
     if (NonNullOrPoisonValues.count(SrcValue)) {
       continue;
+    } else if (auto *GEP = castToInBoundsGEP(SrcValue)) {
+      NonNullOrPoisonValues.insert(GEP);
     } else if (auto *SrcPN = dyn_cast<PHINode>(SrcValue)) {
       if (!isNonNullOrPoisonPhi(VisitedPhis, SrcPN))
-	return false;
+        return false;
     } else {
       return false;
     }
@@ -194,75 +266,134 @@ NullCheckElimination::isNonNullOrPoisonPhi(SmallPhiSet *VisitedPhis,
   return true;
 }
 
-/// Determines whether an ICmpInst is a null check of a known nonnull-or-poison
-/// value.
-NullCheckElimination::NullCheckResult
-NullCheckElimination::isCmpNullCheck(ICmpInst *CI) {
-  if (!CI->isEquality())
-    return NotNullCheck;
+/// Determines whether a phi corresponds to an inbounds recurrence where the
+/// base is not a known nonnull-or-poison value. Returns the base value, or
+/// null if the phi doesn't correspond to such a recurrence.
+Value *NullCheckElimination::isNontrivialInBoundsRecurrence(PHINode *PN) {
+  if (PN->getNumOperands() != 2)
+    return nullptr;
 
-  unsigned constantIndex;
-  if (NonNullOrPoisonValues.count(CI->getOperand(0)))
-    constantIndex = 1;
-  else if (NonNullOrPoisonValues.count(CI->getOperand(1)))
-    constantIndex = 0;
-  else
-    return NotNullCheck;
+  Value *BaseV;
+  GetElementPtrInst *SuccessorI;
+  if (auto *GEP = castToInBoundsGEP(PN->getOperand(0))) {
+    BaseV = PN->getOperand(1);
+    SuccessorI = GEP;
+  } else if (auto *GEP = castToInBoundsGEP(PN->getOperand(1))) {
+    BaseV = PN->getOperand(0);
+    SuccessorI = GEP;
+  } else {
+    return nullptr;
+  }
 
-  auto *C = dyn_cast<Constant>(CI->getOperand(constantIndex));
-  if (!C || !C->isZeroValue())
-    return NotNullCheck;
+  if (NonNullOrPoisonValues.count(BaseV) || SuccessorI->getOperand(0) != PN)
+    return nullptr;
 
-  return
-    CI->getPredicate() == llvm::CmpInst::ICMP_EQ ? NullCheckEq : NullCheckNe;
+  return BaseV;
 }
 
-/// Finds the Use, if any, of an ICmpInst null check of a nonnull-or-poison
-/// value.
-std::pair<Use*, NullCheckElimination::NullCheckResult>
-NullCheckElimination::findNullCheck(Use *U) {
+/// Determines whether an ICmpInst is one of the forms that is relevant to
+/// null check elimination, and then adds a CmpDesc to Cmps when applicable.
+/// The ICmpInst is passed as a Use so this Use can be placed into the CmpDesc,
+/// but the Use parameter must be a Use of an ICmpInst.
+bool NullCheckElimination::classifyCmp(CmpDescVec *Cmps, Use *U) {
+  auto *CI = cast<ICmpInst>(U);
+  if (!CI->isEquality())
+    return false;
+
+  CmpPred Pred = (CI->getPredicate() == llvm::CmpInst::ICMP_EQ) ? CmpEq : CmpNe;
+  Value *Op0 = CI->getOperand(0);
+  Value *Op1 = CI->getOperand(1);
+
+  if (NonNullOrPoisonValues.count(Op0)) {
+    if (isZeroConstant(Op1)) {
+      Cmps->push_back(CmpDesc(NullCheckDefiniteCmp, Pred, U, Op0));
+      return true;
+    }
+
+    auto it = InBoundsRecurrenceBaseMap.find(Op1);
+    if (it == InBoundsRecurrenceBaseMap.end())
+      return false;
+
+    auto *GEP = castToInBoundsGEP(Op0);
+    if (!GEP)
+      return false;
+
+    auto *BaseV = it->second;
+    if (GEP->getOperand(0) != BaseV)
+      return false;
+
+    Cmps->push_back(CmpDesc(RecurrencePhiBoundCmp, Pred, U, Op1));
+    return true;
+  }
+
+  // Since InstCombine or InstSimplify should have canonicalized a comparison
+  // with `null` to have the `null` in the second operand, we don't need to
+  // handle the case where Op0 is `null` like we did with Op1 above.
+  if (NonNullOrPoisonValues.count(Op1)) {
+    auto it = InBoundsRecurrenceBaseMap.find(Op0);
+    if (it == InBoundsRecurrenceBaseMap.end())
+      return false;
+
+    auto *GEP = castToInBoundsGEP(Op1);
+    if (!GEP)
+      return false;
+
+    auto *BaseV = it->second;
+    if (GEP->getOperand(0) != BaseV)
+      return false;
+
+    Cmps->push_back(CmpDesc(RecurrencePhiBoundCmp, Pred, U, Op0));
+    return true;
+  }
+
+  if (InBoundsRecurrenceBaseMap.count(Op0)) {
+    if (isZeroConstant(Op1)) {
+      Cmps->push_back(CmpDesc(NullCheckRecurrenceCmp, Pred, U, Op0));
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/// Classifies the comparisons that are relevant to null check elimination,
+/// starting from a Use. The CmpDescs of the comparisons are collected in Cmps.
+bool NullCheckElimination::findRelevantCmps(CmpDescVec *Cmps, Use *U) {
   auto *I = dyn_cast<Instruction>(U->get());
   if (!I)
-    return std::make_pair(nullptr, NotNullCheck);
+    return false;
 
-  if (auto *CI = dyn_cast<ICmpInst>(I)) {
-    NullCheckResult result = isCmpNullCheck(CI);
-    if (result == NotNullCheck)
-      return std::make_pair(nullptr, NotNullCheck);
-    else
-      return std::make_pair(U, result);
+  if (isa<ICmpInst>(I))
+    return classifyCmp(Cmps, U);
+
+  unsigned Opcode = I->getOpcode();
+  if (Opcode == Instruction::Or || Opcode == Instruction::And) {
+    bool FoundCmps = findRelevantCmps(Cmps, &I->getOperandUse(0));
+    FoundCmps |= findRelevantCmps(Cmps, &I->getOperandUse(1));
+    return FoundCmps;
   }
 
-  unsigned opcode = I->getOpcode();
-  if (opcode == Instruction::Or || opcode == Instruction::And) {
-    auto result = findNullCheck(&I->getOperandUse(0));
-    if (result.second == NotNullCheck)
-      return findNullCheck(&I->getOperandUse(1));
-    else
-      return result;
-  }
-
-  return std::make_pair(nullptr, NotNullCheck);
+  return false;
 }
 
 /// Determines whether `BB` contains a load from `PtrV`, or any inbounds GEP
 /// derived from `PtrV`.
 bool
 NullCheckElimination::blockContainsLoadDerivedFrom(BasicBlock *BB,
-						   Value *PtrV) {
+                                                   Value *PtrV) {
   for (auto &I : *BB) {
     auto *LI = dyn_cast<LoadInst>(&I);
     if (!LI)
       continue;
 
     Value *V = LI->getPointerOperand();
-    while (NonNullOrPoisonValues.count(V)) {
+    while (1) {
       if (V == PtrV)
-	return true;
+        return true;
 
-      auto *GEP = dyn_cast<GetElementPtrInst>(V);
+      auto *GEP = castToInBoundsGEP(V);
       if (!GEP)
-	break;
+        break;
 
       V = GEP->getOperand(0);
     }

--- a/test/Transforms/NullCheckElimination/basic.ll
+++ b/test/Transforms/NullCheckElimination/basic.ll
@@ -22,6 +22,28 @@ return:
   ret i64 0
 }
 
+define i64 @test_arg_simple_ne(i64* nonnull %p) {
+entry:
+  br label %loop_body
+
+loop_body:
+  %p0 = phi i64* [ %p, %entry ], [ %p1, %match_else ]
+  %b0 = icmp ne i64* %p0, null
+  br i1 %b0, label %match_else, label %return
+
+; CHECK-LABEL: @test_arg_simple
+; CHECK-NOT: , null
+
+match_else:
+  %i0 = load i64* %p0
+  %p1 = getelementptr inbounds i64* %p0, i64 1
+  %b1 = icmp ugt i64 %i0, 10
+  br i1 %b1, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
 define i64 @test_arg_simple_fail(i64* %p) {
 entry:
   br label %loop_body
@@ -32,6 +54,31 @@ loop_body:
   br i1 %b0, label %return, label %match_else
 
 ; CHECK-LABEL: @test_arg_simple_fail
+; CHECK: null
+
+match_else:
+  %i0 = load i64* %p0
+  %p1 = getelementptr inbounds i64* %p0, i64 1
+  %b1 = icmp ugt i64 %i0, 10
+  br i1 %b1, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
+define i64 @test_arg_simple_fail_control_dep(i64* nonnull %p) {
+entry:
+  br label %loop_body
+
+loop_body:
+  %p0 = phi i64* [ %p, %entry ], [ %p1, %match_else ]
+  br i1 undef, label %loop_body2, label %match_else
+
+loop_body2:
+  %b0 = icmp eq i64* %p0, null
+  br i1 %b0, label %return, label %match_else
+
+; CHECK-LABEL: @test_arg_simple_fail_control_dep
 ; CHECK: null
 
 match_else:
@@ -67,6 +114,29 @@ return:
   ret i64 0
 }
 
+define i64 @test_inbounds_simple_ne(i64* %p) {
+entry:
+  %p0 = getelementptr inbounds i64* %p, i64 0
+  br label %loop_body
+
+loop_body:
+  %p1 = phi i64* [ %p0, %entry ], [ %p2, %match_else ]
+  %b0 = icmp ne i64* %p1, null
+  br i1 %b0, label %match_else, label %return
+
+; CHECK-LABEL: @test_inbounds_simple
+; CHECK-NOT: null
+
+match_else:
+  %i0 = load i64* %p1
+  %p2 = getelementptr inbounds i64* %p1, i64 1
+  %b1 = icmp ugt i64 %i0, 10
+  br i1 %b1, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
 define i64 @test_inbounds_simple_fail(i64* %p) {
 entry:
   %p0 = getelementptr i64* %p, i64 0
@@ -78,6 +148,32 @@ loop_body:
   br i1 %b0, label %return, label %match_else
 
 ; CHECK-LABEL: @test_inbounds_simple_fail
+; CHECK: null
+
+match_else:
+  %i0 = load i64* %p1
+  %p2 = getelementptr inbounds i64* %p1, i64 1
+  %b1 = icmp ugt i64 %i0, 10
+  br i1 %b1, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
+define i64 @test_inbounds_simple_fail_control_dep(i64* %p) {
+entry:
+  %p0 = getelementptr i64* %p, i64 0
+  br label %loop_body
+
+loop_body:
+  %p1 = phi i64* [ %p0, %entry ], [ %p2, %match_else ]
+  br i1 undef, label %loop_body2, label %match_else
+
+loop_body2:
+  %b0 = icmp eq i64* %p1, null
+  br i1 %b0, label %return, label %match_else
+
+; CHECK-LABEL: @test_inbounds_simple_fail_control_dep
 ; CHECK: null
 
 match_else:
@@ -156,6 +252,30 @@ loop_body:
 match_else:
   %p2 = getelementptr inbounds i64* %p1, i64 1
   %i0 = load i64* %p2
+  %b1 = icmp ugt i64 %i0, 10
+  br i1 %b1, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
+define i64 @test_inbounds_derived_load_fail(i64* %p) {
+entry:
+  %p0 = getelementptr inbounds i64* %p, i64 0
+  br label %loop_body
+
+loop_body:
+  %p1 = phi i64* [ %p0, %entry ], [ %p2, %match_else ]
+  %b0 = icmp eq i64* %p1, null
+  br i1 %b0, label %return, label %match_else
+
+; CHECK-LABEL: @test_inbounds_derived_load_fail
+; CHECK: icmp eq i64* %p1, null
+
+match_else:
+  %p2 = getelementptr inbounds i64* %p1, i64 1
+  %p3 = getelementptr i64* %p1, i64 1
+  %i0 = load i64* %p3
   %b1 = icmp ugt i64 %i0, 10
   br i1 %b1, label %return, label %loop_body
 

--- a/test/Transforms/NullCheckElimination/complex.ll
+++ b/test/Transforms/NullCheckElimination/complex.ll
@@ -1,0 +1,316 @@
+; RUN: opt < %s -null-check-elimination -instsimplify -S | FileCheck %s
+
+define i64 @test_arg_multiple(i64* nonnull %p, i64* nonnull %q) {
+entry:
+  br label %loop_body
+
+loop_body:
+  %p0 = phi i64* [ %p, %entry ], [ %p1, %match_else ]
+  %q0 = phi i64* [ %q, %entry ], [ %q1, %match_else ]
+  %b0 = icmp eq i64* %p0, null
+  %b1 = icmp eq i64* %q0, null
+  %b2 = or i1 %b0, %b1
+  br i1 %b2, label %return, label %match_else
+
+; CHECK-LABEL: @test_arg_multiple
+; CHECK-NOT: , null
+
+match_else:
+  %i0 = load i64* %p0
+  %i1 = load i64* %q0
+  %p1 = getelementptr inbounds i64* %p0, i64 1
+  %q1 = getelementptr inbounds i64* %q0, i64 1
+  %b3 = icmp ugt i64 %i0, 10
+  br i1 %b3, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
+define i64 @test_arg_multiple_fail(i64* nonnull %p, i64* %q) {
+entry:
+  br label %loop_body
+
+loop_body:
+  %p0 = phi i64* [ %p, %entry ], [ %p1, %match_else ]
+  %q0 = phi i64* [ %q, %entry ], [ %q1, %match_else ]
+  %b0 = icmp eq i64* %p0, null
+  %b1 = icmp eq i64* %q0, null
+  %b2 = or i1 %b0, %b1
+  br i1 %b2, label %return, label %match_else
+
+; CHECK-LABEL: @test_arg_multiple_fail
+; CHECK-NOT: icmp eq i64* %p0, null
+; CHECK: icmp eq i64* %q0, null
+
+match_else:
+  %i0 = load i64* %p0
+  %i1 = load i64* %q0
+  %p1 = getelementptr inbounds i64* %p0, i64 1
+  %q1 = getelementptr inbounds i64* %q0, i64 1
+  %b3 = icmp ugt i64 %i0, 10
+  br i1 %b3, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
+define i64 @test_inbounds_multiple(i64* %p, i64* %q) {
+entry:
+  %p0 = getelementptr inbounds i64* %p, i64 0
+  %q0 = getelementptr inbounds i64* %q, i64 0
+  br label %loop_body
+
+loop_body:
+  %p1 = phi i64* [ %p0, %entry ], [ %p2, %match_else ]
+  %q1 = phi i64* [ %q0, %entry ], [ %q2, %match_else ]
+  %b0 = icmp eq i64* %p1, null
+  %b1 = icmp eq i64* %q1, null
+  %b2 = or i1 %b0, %b1
+  br i1 %b2, label %return, label %match_else
+
+; CHECK-LABEL: @test_inbounds_multiple
+; CHECK-NOT: , null
+
+match_else:
+  %i0 = load i64* %p1
+  %i1 = load i64* %q1
+  %p2 = getelementptr inbounds i64* %p1, i64 1
+  %q2 = getelementptr inbounds i64* %q1, i64 1
+  %b3 = icmp ugt i64 %i0, 10
+  br i1 %b3, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
+define i64 @test_inbounds_multiple_fail(i64* %p, i64* %q) {
+entry:
+  %p0 = getelementptr i64* %p, i64 0
+  %q0 = getelementptr inbounds i64* %q, i64 0
+  br label %loop_body
+
+loop_body:
+  %p1 = phi i64* [ %p0, %entry ], [ %p2, %match_else ]
+  %q1 = phi i64* [ %q0, %entry ], [ %q2, %match_else ]
+  %b0 = icmp eq i64* %p1, null
+  %b1 = icmp eq i64* %q1, null
+  %b2 = or i1 %b0, %b1
+  br i1 %b2, label %return, label %match_else
+
+; CHECK-LABEL: @test_inbounds_multiple_fail
+; CHECK: icmp eq i64* %p1, null
+; CHECK-NOT: icmp eq i64* %q1, null
+
+match_else:
+  %i0 = load i64* %p1
+  %i1 = load i64* %q1
+  %p2 = getelementptr inbounds i64* %p1, i64 1
+  %q2 = getelementptr inbounds i64* %q1, i64 1
+  %b3 = icmp ugt i64 %i0, 10
+  br i1 %b3, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
+define i64 @test_inbounds_recurrence_or(i64* %p, i64 %len) {
+entry:
+  %q = getelementptr inbounds i64* %p, i64 %len
+  br label %loop_body
+
+loop_body:
+  %p0 = phi i64* [ %p, %entry ], [ %p1, %match_else ]
+  %b0 = icmp eq i64* %p0, %q
+  %b1 = icmp eq i64* %p0, null
+  %b2 = or i1 %b0, %b1
+  br i1 %b2, label %return, label %match_else
+
+; CHECK-LABEL: @test_inbounds_recurrence_or
+; CHECK-NOT: null
+
+match_else:
+  %i0 = load i64* %p0
+  %p1 = getelementptr inbounds i64* %p0, i64 1
+  %b3 = icmp ugt i64 %i0, 10
+  br i1 %b3, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
+define i64 @test_inbounds_recurrence_or_fail1(i64* %p, i64 %len) {
+entry:
+  %q = getelementptr i64* %p, i64 %len
+  br label %loop_body
+
+loop_body:
+  %p0 = phi i64* [ %p, %entry ], [ %p1, %match_else ]
+  %b0 = icmp eq i64* %p0, %q
+  %b1 = icmp eq i64* %p0, null
+  %b2 = or i1 %b0, %b1
+  br i1 %b2, label %return, label %match_else
+
+; CHECK-LABEL: @test_inbounds_recurrence_or_fail1
+; CHECK: icmp eq i64* %p0, null
+
+match_else:
+  %i0 = load i64* %p0
+  %p1 = getelementptr inbounds i64* %p0, i64 1
+  %b3 = icmp ugt i64 %i0, 10
+  br i1 %b3, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
+define i64 @test_inbounds_recurrence_or_fail2(i64* %p, i64 %len) {
+entry:
+  %q = getelementptr inbounds i64* %p, i64 %len
+  br label %loop_body
+
+loop_body:
+  %p0 = phi i64* [ %p, %entry ], [ %p1, %match_else ]
+  %b0 = icmp eq i64* %p0, %q
+  %b1 = icmp eq i64* %p0, null
+  %b2 = or i1 %b0, %b1
+  br i1 %b2, label %return, label %match_else
+
+; CHECK-LABEL: @test_inbounds_recurrence_or_fail2
+; CHECK: icmp eq i64* %p0, null
+
+match_else:
+  %i0 = load i64* %p0
+  %p1 = getelementptr i64* %p0, i64 1
+  %b3 = icmp ugt i64 %i0, 10
+  br i1 %b3, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
+define i64 @test_inbounds_recurrence_and(i64* %p, i64 %len) {
+entry:
+  %q = getelementptr inbounds i64* %p, i64 %len
+  br label %loop_body
+
+loop_body:
+  %p0 = phi i64* [ %p, %entry ], [ %p1, %match_else ]
+  %b0 = icmp eq i64* %p0, %q
+  %b1 = icmp eq i64* %p0, null
+  %b2 = or i1 %b0, %b1
+  br i1 %b2, label %return, label %match_else
+
+; CHECK-LABEL: @test_inbounds_recurrence_and
+; CHECK-NOT: null
+
+match_else:
+  %i0 = load i64* %p0
+  %p1 = getelementptr inbounds i64* %p0, i64 1
+  %b3 = icmp ugt i64 %i0, 10
+  br i1 %b3, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
+define i64 @test_inbounds_recurrence_or_rev(i64* %p, i64 %len) {
+entry:
+  %q = getelementptr inbounds i64* %p, i64 %len
+  br label %loop_body
+
+loop_body:
+  %p0 = phi i64* [ %p1, %match_else ], [ %p, %entry ]
+  %b0 = icmp eq i64* %p0, null
+  %b1 = icmp eq i64* %q, %p0
+  %b2 = or i1 %b0, %b1
+  br i1 %b2, label %return, label %match_else
+
+; CHECK-LABEL: @test_inbounds_recurrence_or_rev
+; CHECK-NOT: null
+
+match_else:
+  %i0 = load i64* %p0
+  %p1 = getelementptr inbounds i64* %p0, i64 1
+  %b3 = icmp ugt i64 %i0, 10
+  br i1 %b3, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
+define i64 @test_inbounds_recurrence_or_rev_fail1(i64* %p, i64 %len) {
+entry:
+  %q = getelementptr i64* %p, i64 %len
+  br label %loop_body
+
+loop_body:
+  %p0 = phi i64* [ %p1, %match_else ], [ %p, %entry ]
+  %b0 = icmp eq i64* %p0, null
+  %b1 = icmp eq i64* %q, %p0
+  %b2 = or i1 %b0, %b1
+  br i1 %b2, label %return, label %match_else
+
+; CHECK-LABEL: @test_inbounds_recurrence_or_rev_fail1
+; CHECK: icmp eq i64* %p0, null
+
+match_else:
+  %i0 = load i64* %p0
+  %p1 = getelementptr inbounds i64* %p0, i64 1
+  %b3 = icmp ugt i64 %i0, 10
+  br i1 %b3, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
+define i64 @test_inbounds_recurrence_or_rev_fail2(i64* %p, i64 %len) {
+entry:
+  %q = getelementptr inbounds i64* %p, i64 %len
+  br label %loop_body
+
+loop_body:
+  %p0 = phi i64* [ %p1, %match_else ], [ %p, %entry ]
+  %b0 = icmp eq i64* %p0, null
+  %b1 = icmp eq i64* %q, %p0
+  %b2 = or i1 %b0, %b1
+  br i1 %b2, label %return, label %match_else
+
+; CHECK-LABEL: @test_inbounds_recurrence_or_rev_fail2
+; CHECK: icmp eq i64* %p0, null
+
+match_else:
+  %i0 = load i64* %p0
+  %p1 = getelementptr i64* %p0, i64 1
+  %b3 = icmp ugt i64 %i0, 10
+  br i1 %b3, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+
+define i64 @test_inbounds_recurrence_and_rev(i64* %p, i64 %len) {
+entry:
+  %q = getelementptr inbounds i64* %p, i64 %len
+  br label %loop_body
+
+loop_body:
+  %p0 = phi i64* [ %p1, %match_else ], [ %p, %entry ]
+  %b0 = icmp eq i64* %p0, null
+  %b1 = icmp eq i64* %q, %p0
+  %b2 = or i1 %b0, %b1
+  br i1 %b2, label %return, label %match_else
+
+; CHECK-LABEL: @test_inbounds_recurrence_and_rev
+; CHECK-NOT: null
+
+match_else:
+  %i0 = load i64* %p0
+  %p1 = getelementptr inbounds i64* %p0, i64 1
+  %b3 = icmp ugt i64 %i0, 10
+  br i1 %b3, label %return, label %loop_body
+
+return:
+  ret i64 0
+}
+


### PR DESCRIPTION
Teach the NullCheckElimination pass about recurrences involving inbounds
GEPs. This allows the pass to optimize null checks from most uses of
single slice and vector iterators.

This still isn't sufficient to eliminate null checks from uses of
multiple iterators with zip().

I also had my editor set to convert 8 spaces to a tab from a previous
project, so I'm undoing that here.
