### PR TITLE
Segmented Stacks support for DragonFly

### DIFF
--- a/lib/Target/X86/X86FrameLowering.cpp
+++ b/lib/Target/X86/X86FrameLowering.cpp
@@ -1328,7 +1328,8 @@ X86FrameLowering::adjustForSegmentedStacks(MachineFunction &MF) const {
   if (MF.getFunction()->isVarArg())
     report_fatal_error("Segmented stacks do not support vararg functions.");
   if (!STI.isTargetLinux() && !STI.isTargetDarwin() &&
-      !STI.isTargetWin32() && !STI.isTargetWin64() && !STI.isTargetFreeBSD())
+      !STI.isTargetWin32() && !STI.isTargetWin64() && 
+      !STI.isTargetFreeBSD() && !STI.isTargetDragonFly())
     report_fatal_error("Segmented stacks not supported on this platform.");
 
   // Eventually StackSize will be calculated by a link-time pass; which will
@@ -1382,6 +1383,10 @@ X86FrameLowering::adjustForSegmentedStacks(MachineFunction &MF) const {
     } else if (STI.isTargetFreeBSD()) {
       TlsReg = X86::FS;
       TlsOffset = 0x18;
+    } else if (STI.isTargetDragonFly()) {
+      // use tls_tcb.tcb_unused[0]
+      TlsReg = X86::FS;
+      TlsOffset = 0x20;
     } else {
       report_fatal_error("Segmented stacks not supported on this platform.");
     }

--- a/lib/Target/X86/X86Subtarget.h
+++ b/lib/Target/X86/X86Subtarget.h
@@ -371,6 +371,9 @@ public:
   bool isTargetFreeBSD() const {
     return TargetTriple.getOS() == Triple::FreeBSD;
   }
+  bool isTargetDragonFly() const {
+    return TargetTriple.getOS() == Triple::DragonFly;
+  }
   bool isTargetSolaris() const {
     return TargetTriple.getOS() == Triple::Solaris;
   }


### PR DESCRIPTION
In the effort of porting Rust to DragonFlyBSD, I noticed that my modified rust compiler (https://github.com/mneumann/rust/tree/dragonfly) fails with <tt>"Segmented stacks not supported on this platform."</tt>. This fixes it.
