### PR TITLE
Fix crash when looking up the addrspace of GEPs with vector types

### DIFF
--- a/include/llvm/IR/Operator.h
+++ b/include/llvm/IR/Operator.h
@@ -402,7 +402,7 @@ public:
   /// getPointerAddressSpace - Method to return the address space of the
   /// pointer operand.
   unsigned getPointerAddressSpace() const {
-    return cast<PointerType>(getPointerOperandType())->getAddressSpace();
+    return getPointerOperandType()->getPointerAddressSpace();
   }
 
   unsigned getNumIndices() const {  // Note: always non-negative

--- a/test/Transforms/MergeFunc/vector-GEP-crash.ll
+++ b/test/Transforms/MergeFunc/vector-GEP-crash.ll
@@ -1,0 +1,12 @@
+; RUN: opt -mergefunc -disable-output < %s
+; This used to cause a crash when compairing the GEPs
+
+define void @foo(<2 x i64*>) {
+  %tmp = getelementptr <2 x i64*> %0, <2 x i64> <i64 0, i64 0>
+  ret void
+}
+
+define void @bar(<2 x i64*>) {
+  %tmp = getelementptr <2 x i64*> %0, <2 x i64> <i64 0, i64 0>
+  ret void
+}


### PR DESCRIPTION
Solves a mergefunc crash in rustc
