### PR TITLE
Disable the PassInfo cache assertions to make the cache effective in builds with assertions enabld

### DIFF
--- a/lib/IR/LegacyPassManager.cpp
+++ b/lib/IR/LegacyPassManager.cpp
@@ -733,9 +733,6 @@ const PassInfo *PMTopLevelManager::findAnalysisPassInfo(AnalysisID AID) const {
   const PassInfo *&PI = AnalysisPassInfos[AID];
   if (!PI)
     PI = PassRegistry::getPassRegistry()->getPassInfo(AID);
-  else
-    assert(PI == PassRegistry::getPassRegistry()->getPassInfo(AID) &&
-           "The pass info pointer changed for an analysis ID!");
 
   return PI;
 }


### PR DESCRIPTION
Since the PassInfo cache does a regular, uncached, slow lookup for the
asserted condition, it's not very effective _cough_ when assertions are
enabled. Since disabling these assertions gives quite a nice perf boost
and it's not really worse than the patch we had previously, let's just
do that.
