### PR TITLE
Add certain jemalloc functions to MemoryBuiltins

### DIFF
--- a/include/llvm/Target/TargetLibraryInfo.h
+++ b/include/llvm/Target/TargetLibraryInfo.h
@@ -371,6 +371,10 @@ namespace llvm {
       isascii,
       /// int isdigit(int c);
       isdigit,
+      /// void *je_mallocx(size_t size, int flags);
+      je_mallocx,
+      /// void *je_sdallocx(void *ptr, size_t size, int flags)
+      je_sdallocx,
       /// long int labs(long int j);
       labs,
       /// int lchown(const char *path, uid_t owner, gid_t group);
@@ -687,6 +691,7 @@ namespace llvm {
       vsscanf,
       /// ssize_t write(int fildes, const void *buf, size_t nbyte);
       write,
+
 
       NumLibFuncs
     };

--- a/lib/Analysis/MemoryBuiltins.cpp
+++ b/lib/Analysis/MemoryBuiltins.cpp
@@ -66,7 +66,8 @@ static const AllocFnsTy AllocationFnData[] = {
   {LibFunc::realloc,             ReallocLike, 2, 1,  -1},
   {LibFunc::reallocf,            ReallocLike, 2, 1,  -1},
   {LibFunc::strdup,              StrDupLike,  1, -1, -1},
-  {LibFunc::strndup,             StrDupLike,  2, 1,  -1}
+  {LibFunc::strndup,             StrDupLike,  2, 1,  -1},
+  {LibFunc::je_mallocx,          MallocLike,  2, 0,  -1}
   // TODO: Handle "int posix_memalign(void **, size_t, size_t)"
 };
 
@@ -339,6 +340,8 @@ const CallInst *llvm::isFreeCall(const Value *I, const TargetLibraryInfo *TLI) {
            TLIFn == LibFunc::ZdaPvm ||              // delete[](void*, ulong)
            TLIFn == LibFunc::ZdaPvRKSt9nothrow_t)   // delete[](void*, nothrow)
     ExpectedNumParams = 2;
+  else if (TLIFn == LibFunc::je_sdallocx)
+    ExpectedNumParams = 3;
   else
     return nullptr;
 

--- a/lib/Target/TargetLibraryInfo.cpp
+++ b/lib/Target/TargetLibraryInfo.cpp
@@ -198,6 +198,8 @@ const char* TargetLibraryInfo::StandardNames[LibFunc::NumLibFuncs] =
     "iprintf",
     "isascii",
     "isdigit",
+    "je_mallocx",
+    "je_sdallocx",
     "labs",
     "lchown",
     "ldexp",


### PR DESCRIPTION
This informs LLVM that they return noalias pointers, and allows "dead" allocations to be optimized out.
