### PR TITLE
Add accessors for MCSubtargetInfo CPU and Feature tables

### DIFF
--- a/include/llvm/MC/MCSubtargetInfo.h
+++ b/include/llvm/MC/MCSubtargetInfo.h
@@ -163,6 +163,14 @@ public:
     auto Found = std::lower_bound(ProcDesc.begin(), ProcDesc.end(), CPU);
     return Found != ProcDesc.end() && StringRef(Found->Key) == CPU;
   }
+
+  ArrayRef<SubtargetFeatureKV> getCPUTable() const {
+    return ProcDesc;
+  }
+
+  ArrayRef<SubtargetFeatureKV> getFeatureTable() const {
+    return ProcFeatures;
+  }
 };
 
 } // End llvm namespace


### PR DESCRIPTION
This is part of a fix for https://github.com/rust-lang/rust/issues/30961. The rustc fix requires exposing some private members on MCSubtargetInfo so they can be printed from rustc.
