### PR TITLE
Add accessors for MCSubtargetInfo CPU and Feature tables

### DIFF
--- a/include/llvm/MC/MCSubtargetInfo.h
+++ b/include/llvm/MC/MCSubtargetInfo.h
@@ -164,6 +164,14 @@ public:
     auto Found = std::lower_bound(ProcDesc.begin(), ProcDesc.end(), CPU);
     return Found != ProcDesc.end() && StringRef(Found->Key) == CPU;
   }
+
+  ArrayRef<SubtargetFeatureKV> getCPUTable() const {
+    return ProcDesc;
+  }
+
+  ArrayRef<SubtargetFeatureKV> getFeatureTable() const {
+    return ProcFeatures;
+  }
 };
 
 } // End llvm namespace


### PR DESCRIPTION
Required for https://github.com/rust-lang/rust/pull/34845 - add help for target CPUs, features, relocation and code models.
