### PR TITLE
Add support for DW_AT_main_subprogram

### DIFF
--- a/include/llvm/IR/DebugInfoFlags.def
+++ b/include/llvm/IR/DebugInfoFlags.def
@@ -38,5 +38,6 @@ HANDLE_DI_FLAG((2 << 16), MultipleInheritance)
 HANDLE_DI_FLAG((3 << 16), VirtualInheritance)
 HANDLE_DI_FLAG((1 << 18), IntroducedVirtual)
 HANDLE_DI_FLAG((1 << 19), BitField)
+HANDLE_DI_FLAG((1 << 21), MainSubprogram)
 
 #undef HANDLE_DI_FLAG

--- a/include/llvm/IR/DebugInfoMetadata.h
+++ b/include/llvm/IR/DebugInfoMetadata.h
@@ -1402,6 +1402,7 @@ public:
   }
   bool isExplicit() const { return getFlags() & FlagExplicit; }
   bool isPrototyped() const { return getFlags() & FlagPrototyped; }
+  bool isMainSubprogram() const { return getFlags() & FlagMainSubprogram; }
 
   /// \brief Check if this is reference-qualified.
   ///

--- a/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -1260,6 +1260,9 @@ void DwarfUnit::applySubprogramAttributes(const DISubprogram *SP, DIE &SPDie,
 
   if (SP->isExplicit())
     addFlag(SPDie, dwarf::DW_AT_explicit);
+
+  if (SP->isMainSubprogram())
+    addFlag(SPDie, dwarf::DW_AT_main_subprogram);
 }
 
 void DwarfUnit::constructSubrangeDIE(DIE &Buffer, const DISubrange *SR,

--- a/test/DebugInfo/Generic/mainsubprogram.ll
+++ b/test/DebugInfo/Generic/mainsubprogram.ll
@@ -1,0 +1,35 @@
+; REQUIRES: object-emission
+
+; RUN: %llc_dwarf -O0 -filetype=obj < %s > %t
+; RUN: llvm-dwarfdump -debug-dump=info %t | FileCheck %s
+
+; Make sure we're emitting DW_AT_main_subprogram.
+; CHECK: DW_TAG_subprogram
+; CHECK-NOT: {{DW_TAG|NULL}}
+; CHECK: DW_AT_name {{.*}} "main"
+; CHECK-NOT: {{DW_TAG|NULL}}
+; CHECK:   DW_AT_main_subprogram [DW_FORM_flag_present] (true)
+
+define i32 @main() #0 !dbg !4 {
+entry:
+  %retval = alloca i32, align 4
+  store i32 0, i32* %retval
+  ret i32 0, !dbg !10
+}
+
+attributes #0 = { nounwind uwtable "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!9, !11}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, producer: "clang version 3.4 (trunk 185475)", isOptimized: false, emissionKind: FullDebug, file: !1, enums: !2, retainedTypes: !2, globals: !2, imports: !2)
+!1 = !DIFile(filename: "CodeGen/dwarf-version.c", directory: "test")
+!2 = !{}
+!4 = distinct !DISubprogram(name: "main", line: 6, isLocal: false, isDefinition: true, virtualIndex: 6, flags: DIFlagPrototyped | DIFlagMainSubprogram, isOptimized: false, unit: !0, scopeLine: 6, file: !1, scope: !5, type: !6, variables: !2)
+!5 = !DIFile(filename: "CodeGen/dwarf-version.c", directory: "test")
+!6 = !DISubroutineType(types: !7)
+!7 = !{!8}
+!8 = !DIBasicType(tag: DW_TAG_base_type, name: "int", size: 32, align: 32, encoding: DW_ATE_signed)
+!9 = !{i32 2, !"Dwarf Version", i32 4}
+!10 = !DILocation(line: 7, scope: !4)
+!11 = !{i32 1, !"Debug Info Version", i32 3}


### PR DESCRIPTION
I'd like the Rust compiler to emit DW_AT_main_subprogram in its DWARF
output, so that debuggers can find the user-provided main entry point.
See https://github.com/rust-lang/rust/issues/32620

This patch adds support for DW_AT_main_subprogram to LLVM to support
this effort.

A variant of this patch was accepted by upstream LLVM; there,
DebugInfoFlags.def already has a flag with value 1<<20, which is why
this patch uses 1<<21 -- this will avoid the need to change the Rust
compiler when a new LLVM is imported.

I could not run the included test case with the rust fork of LLVM.  There is a build failure - invalid C++ in some gtest.  However, I did manage to run it against upstream LLVM; and I did test this patch by rebuilding my modified rustc against it.