### PR TITLE
Add relocations for fixups fixup_arm_thumb_{br,bcc}

### DIFF
--- a/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp
+++ b/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp
@@ -140,6 +140,12 @@ unsigned ARMELFObjectWriter::GetRelocTypeInner(const MCValue &Target,
     case ARM::fixup_t2_movw_lo16:
       Type = ELF::R_ARM_THM_MOVW_PREL_NC;
       break;
+    case ARM::fixup_arm_thumb_br:
+      Type = ELF::R_ARM_THM_JUMP11;
+      break;
+    case ARM::fixup_arm_thumb_bcc:
+      Type = ELF::R_ARM_THM_JUMP8;
+      break;
     case ARM::fixup_arm_thumb_bl:
     case ARM::fixup_arm_thumb_blx:
       switch (Modifier) {

--- a/test/MC/ARM/thumb1-branch-reloc.s
+++ b/test/MC/ARM/thumb1-branch-reloc.s
@@ -1,0 +1,21 @@
+@ RUN: llvm-mc -triple thumbv6-eabi -filetype obj -o - %s | llvm-readobj -r - \
+@ RUN:     | FileCheck %s
+
+        .syntax unified
+
+        .extern h
+        .section .text.uncond
+
+        b h
+        
+@CHECK: Section {{.*}} .rel.text.uncond {
+@CHECK:   0x0 R_ARM_THM_JUMP11
+@CHECK: }
+        .section .text.cond
+
+        ble h
+
+@CHECK: Section {{.*}} .rel.text.cond {
+@CHECK:   0x0 R_ARM_THM_JUMP8
+@CHECK: }
+        


### PR DESCRIPTION
These need to be mapped through to R_ARM_THM_JUMP{11,8} respectively.

Fixes PR30279.

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@280651 91177308-0d34-0410-b5e6-96231b3b80d8

---

backport of [r280651](http://llvm.org/viewvc/llvm-project?view=revision&revision=280651)
fixes rust-lang/rust#38406
r? @alexcrichton 