### PR TITLE
use -O0 when building release LLVM on sparc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -698,6 +698,12 @@ if( MINGW )
   llvm_replace_compiler_option(CMAKE_CXX_FLAGS_RELEASE "-O3" "-O2")
 endif()
 
+if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" AND "${LLVM_NATIVE_ARCH}" MATCHES "Sparc" )
+  # gcc 4.x, 5.x (at least) generate bad code on sparc above -O0 when compiling
+  # llvm; notably llvm-tblgen consistently core dumps.
+  llvm_replace_compiler_option(CMAKE_CXX_FLAGS_RELEASE "-O3" "-O0")
+endif()
+
 # Put this before tblgen. Else we have a circular dependence.
 add_subdirectory(lib/Support)
 add_subdirectory(lib/TableGen)


### PR DESCRIPTION
The bits produced by gcc above -O0 when building rust's private copy of llvm on
sparc result in either versions of llvm-tblgen that consistently segfault or
produce otherwise unuseable code.  This does not affect cross-compiles for some
reason.  Investigation with gcc upstream is in progress.