### PR TITLE
Freebsd Fixes for LLVM 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -845,7 +845,7 @@ if( LLVM_INCLUDE_UTILS )
   add_subdirectory(utils/not)
   add_subdirectory(utils/llvm-lit)
   add_subdirectory(utils/yaml-bench)
-  add_subdirectory(utils/unittest)
+  # add_subdirectory(utils/unittest)
 else()
   if ( LLVM_INCLUDE_TESTS )
     message(FATAL_ERROR "Including tests when not building utils will not work.

--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -105,9 +105,12 @@ endif()
 
 # Pass -Wl,-z,defs. This makes sure all symbols are defined. Otherwise a DSO
 # build might work on ELF but fail on MachO/COFF.
-if(NOT (${CMAKE_SYSTEM_NAME} MATCHES "Darwin" OR WIN32 OR CYGWIN OR
-        ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" OR
-        ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD") AND
+if(NOT (${TARGET_TRIPLE} MATCHES "darwin" OR
+        ${TARGET_TRIPLE} MATCHES "windows" OR
+        ${TARGET_TRIPLE} MATCHES "mingw" OR
+        ${TARGET_TRIPLE} MATCHES "freebsd" OR
+        ${TARGET_TRIPLE} MATCHES "netbsd" OR
+        ${TARGET_TRIPLE} MATCHES "openbsd") AND
    NOT LLVM_USE_SANITIZER)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
 endif()

--- a/lib/Demangle/ItaniumDemangle.cpp
+++ b/lib/Demangle/ItaniumDemangle.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <numeric>

--- a/lib/Support/PrettyStackTrace.cpp
+++ b/lib/Support/PrettyStackTrace.cpp
@@ -22,6 +22,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <cstdarg>
+#include <cstdio>
 #include <tuple>
 
 #ifdef HAVE_CRASHREPORTERCLIENT_H

--- a/lib/Support/TarWriter.cpp
+++ b/lib/Support/TarWriter.cpp
@@ -28,6 +28,8 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/Path.h"
 
+#include <cstdio>
+
 using namespace llvm;
 
 // Each file in an archive must be aligned to this block size.

--- a/tools/dsymutil/DwarfLinker.cpp
+++ b/tools/dsymutil/DwarfLinker.cpp
@@ -1647,7 +1647,7 @@ PointerIntPair<DeclContext *, 1> DeclContextTree::getChildDeclContext(
                         File);
               (void)gotFileName;
               assert(gotFileName && "Must get file name from line table");
-#ifdef HAVE_REALPATH
+#if defined(HAVE_REALPATH) && defined(PATH_MAX)
               char RealPath[PATH_MAX + 1];
               RealPath[PATH_MAX] = 0;
               if (::realpath(File.c_str(), RealPath))

--- a/tools/llvm-xray/CMakeLists.txt
+++ b/tools/llvm-xray/CMakeLists.txt
@@ -14,4 +14,4 @@ set(LLVM_XRAY_TOOLS
   xray-extract.cc
   xray-registry.cc)
 
-add_llvm_tool(llvm-xray llvm-xray.cc ${LLVM_XRAY_TOOLS})
+# add_llvm_tool(llvm-xray llvm-xray.cc ${LLVM_XRAY_TOOLS})


### PR DESCRIPTION
This PR contains three FreeBSD specific fixes, for the fixes themselves see the commit messages.

(Note: While doing the final rebase / cleanup of the LLVM 4.0 upgrade I decided that it would probably be nice to have a PR # associated with each rust modification for future reference / discussion, thus this PR.) 