### PR TITLE
Backport: "[PowerPC] multiply-with-overflow might use the CTR register"

### DIFF
--- a/lib/Target/PowerPC/PPCCTRLoops.cpp
+++ b/lib/Target/PowerPC/PPCCTRLoops.cpp
@@ -298,15 +298,17 @@ bool PPCCTRLoops::mightUseCTR(const Triple &TT, BasicBlock *BB) {
               return true;
             else
               continue; // ISD::FCOPYSIGN is never a library call.
-          case Intrinsic::sqrt:      Opcode = ISD::FSQRT;      break;
-          case Intrinsic::floor:     Opcode = ISD::FFLOOR;     break;
-          case Intrinsic::ceil:      Opcode = ISD::FCEIL;      break;
-          case Intrinsic::trunc:     Opcode = ISD::FTRUNC;     break;
-          case Intrinsic::rint:      Opcode = ISD::FRINT;      break;
-          case Intrinsic::nearbyint: Opcode = ISD::FNEARBYINT; break;
-          case Intrinsic::round:     Opcode = ISD::FROUND;     break;
-          case Intrinsic::minnum:    Opcode = ISD::FMINNUM;    break;
-          case Intrinsic::maxnum:    Opcode = ISD::FMAXNUM;    break;
+          case Intrinsic::sqrt:               Opcode = ISD::FSQRT;      break;
+          case Intrinsic::floor:              Opcode = ISD::FFLOOR;     break;
+          case Intrinsic::ceil:               Opcode = ISD::FCEIL;      break;
+          case Intrinsic::trunc:              Opcode = ISD::FTRUNC;     break;
+          case Intrinsic::rint:               Opcode = ISD::FRINT;      break;
+          case Intrinsic::nearbyint:          Opcode = ISD::FNEARBYINT; break;
+          case Intrinsic::round:              Opcode = ISD::FROUND;     break;
+          case Intrinsic::minnum:             Opcode = ISD::FMINNUM;    break;
+          case Intrinsic::maxnum:             Opcode = ISD::FMAXNUM;    break;
+          case Intrinsic::umul_with_overflow: Opcode = ISD::UMULO;      break;
+          case Intrinsic::smul_with_overflow: Opcode = ISD::SMULO;      break;
           }
         }
 

--- a/test/CodeGen/PowerPC/ctrloop-i128.ll
+++ b/test/CodeGen/PowerPC/ctrloop-i128.ll
@@ -1,0 +1,34 @@
+; RUN: llc -O1 -verify-machineinstrs < %s
+target datalayout = "E-m:e-i64:64-n32:64"
+target triple = "powerpc64-unknown-linux-gnu"
+
+; Function Attrs: uwtable
+define fastcc void @_Crash_Fn() unnamed_addr #0 {
+entry-block:
+  br label %_Label_0
+
+_Label_0:                                         ; preds = %_Label_0, %entry-block
+  %result.0138 = phi i128 [ %5, %_Label_0 ], [ 0, %entry-block ]
+  %iter.sroa.0.0137 = phi i8* [ %0, %_Label_0 ], [ undef, %entry-block ]
+  %0 = getelementptr inbounds i8, i8* %iter.sroa.0.0137, i64 1
+  %1 = tail call { i128, i1 } @llvm.smul.with.overflow.i128(i128 %result.0138, i128 undef) #2
+  %2 = extractvalue { i128, i1 } %1, 0
+  %3 = tail call { i128, i1 } @llvm.sadd.with.overflow.i128(i128 %2, i128 0) #2
+  %4 = extractvalue { i128, i1 } %3, 1
+  %5 = extractvalue { i128, i1 } %3, 0
+  %6 = icmp eq i8* %0, null
+  br i1 %6, label %bb66.loopexit, label %_Label_0
+
+bb66.loopexit:                                    ; preds = %_Label_0
+  unreachable
+}
+
+; Function Attrs: nounwind readnone
+declare { i128, i1 } @llvm.sadd.with.overflow.i128(i128, i128) #1
+
+; Function Attrs: nounwind readnone
+declare { i128, i1 } @llvm.smul.with.overflow.i128(i128, i128) #1
+
+attributes #0 = { uwtable }
+attributes #1 = { nounwind readnone }
+attributes #2 = { nounwind }


### PR DESCRIPTION
Otherwise 128 integer multiplication could produce LLVM Assertions for PowerPC targets.

(Note: While doing the final rebase / cleanup of the LLVM 4.0 upgrade I decided that it would probably be nice to have a PR # associated with each rust modification for future reference / discussion, thus this PR.)
