### PR TITLE
[MSP430] Fix PR32769: Select8 and Select16 need to have SR in Uses.

### DIFF
--- a/lib/Target/MSP430/MSP430InstrInfo.td
+++ b/lib/Target/MSP430/MSP430InstrInfo.td
@@ -122,6 +122,7 @@ def ADJCALLSTACKUP   : Pseudo<(outs), (ins i16imm:$amt1, i16imm:$amt2),
 }
 
 let usesCustomInserter = 1 in {
+  let Uses = [SR] in {
   def Select8  : Pseudo<(outs GR8:$dst), (ins GR8:$src, GR8:$src2, i8imm:$cc),
                         "# Select8 PSEUDO",
                         [(set GR8:$dst,
@@ -130,6 +131,7 @@ let usesCustomInserter = 1 in {
                         "# Select16 PSEUDO",
                         [(set GR16:$dst,
                           (MSP430selectcc GR16:$src, GR16:$src2, imm:$cc))]>;
+  }
   let Defs = [SR] in {
   def Shl8     : Pseudo<(outs GR8:$dst), (ins GR8:$src, GR8:$cnt),
                         "# Shl8 PSEUDO",

--- a/test/CodeGen/MSP430/select-use-sr.ll
+++ b/test/CodeGen/MSP430/select-use-sr.ll
@@ -1,0 +1,21 @@
+; RUN: llc < %s -march=msp430 | FileCheck %s
+; PR32769
+
+target triple = "msp430"
+
+; Test that CMP instruction is not removed by MachineCSE.
+;
+; CHECK-LABEL: @f
+; CHECK: cmp.w r15, r13
+; CHECK: cmp.w r15, r13
+; CHECK-NEXT: jeq .LBB0_2
+define i16 @f(i16, i16, i16, i16) {
+entry:
+  %4 = icmp ult i16 %1, %3
+  %5 = zext i1 %4 to i16
+  %6 = icmp ult i16 %0, %2
+  %7 = zext i1 %6 to i16
+  %8 = icmp eq i16 %1, %3
+  %out = select i1 %8, i16 %5, i16 %7
+  ret i16 %out
+}


### PR DESCRIPTION
If Select pseudo instruction doesn't have use SR, then
CMP instructions are being marked as dead and later can be
removed by MachineCSE pass. This leads to incorrect code
generation.

Differential Revision: https://reviews.llvm.org/D32473

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@301372 91177308-0d34-0410-b5e6-96231b3b80d8