### PR TITLE
Backport two Win64 fixes

### DIFF
--- a/lib/CodeGen/AsmPrinter/WinException.cpp
+++ b/lib/CodeGen/AsmPrinter/WinException.cpp
@@ -68,7 +68,7 @@ void WinException::beginFunction(const MachineFunction *MF) {
 
   const Function *F = MF->getFunction();
 
-  shouldEmitMoves = Asm->needsSEHMoves();
+  shouldEmitMoves = Asm->needsSEHMoves() && MF->hasWinCFI();
 
   const TargetLoweringObjectFile &TLOF = Asm->getObjFileLowering();
   unsigned PerEncoding = TLOF.getPersonalityEncoding();
@@ -94,7 +94,7 @@ void WinException::beginFunction(const MachineFunction *MF) {
 
   // If we're not using CFI, we don't want the CFI or the personality, but we
   // might want EH tables if we had EH pads.
-  if (!Asm->MAI->usesWindowsCFI() || (!MF->hasWinCFI() && !PerFn)) {
+  if (!Asm->MAI->usesWindowsCFI()) {
     if (Per == EHPersonality::MSVC_X86SEH && !hasEHFunclets) {
       // If this is 32-bit SEH and we don't have any funclets (really invokes),
       // make sure we emit the parent offset label. Some unreferenced filter

--- a/lib/Target/X86/X86FrameLowering.cpp
+++ b/lib/Target/X86/X86FrameLowering.cpp
@@ -2952,6 +2952,10 @@ unsigned X86FrameLowering::getWinEHParentFrameOffset(const MachineFunction &MF) 
 
 void X86FrameLowering::processFunctionBeforeFrameFinalized(
     MachineFunction &MF, RegScavenger *RS) const {
+  // Mark the function as not having WinCFI. We will set it back to true in
+  // emitPrologue if it gets called and emits CFI.
+  MF.setHasWinCFI(false);
+
   // If this function isn't doing Win64-style C++ EH, we don't need to do
   // anything.
   const Function *Fn = MF.getFunction();

--- a/test/CodeGen/X86/win64_eh_leaf.ll
+++ b/test/CodeGen/X86/win64_eh_leaf.ll
@@ -29,3 +29,12 @@ entry:
 ; and no unwind info in the object file.
 ; READOBJ-NOT: leaf_func
 }
+
+define void @naked_func() naked {
+  call void asm sideeffect "ret", ""()
+  unreachable
+}
+; ASM-LABEL: naked_func:
+; ASM-NOT: .seh_
+; ASM: ret
+; ASM-NOT: .seh_

--- a/test/CodeGen/X86/win64_eh_leaf2.ll
+++ b/test/CodeGen/X86/win64_eh_leaf2.ll
@@ -1,0 +1,22 @@
+; RUN: llc < %s -O1 -mtriple=x86_64-pc-win32 | FileCheck %s
+
+; Neither of these functions need .seh_ directives. We used to crash.
+
+target datalayout = "e-m:w-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+declare i32 @__CxxFrameHandler3(...)
+
+define void @f1() uwtable nounwind personality i32 (...)* @__CxxFrameHandler3 {
+  ret void
+}
+
+; CHECK-LABEL: f1:
+; CHECK-NOT: .seh_
+
+define void @f2() uwtable {
+  ret void
+}
+
+; CHECK-LABEL: f2:
+; CHECK-NOT: .seh_


### PR DESCRIPTION
* 508425c should _fix rust-lang/rust#41630
* ea87f9f likely _fixes rust-lang/rust#41685 (although I haven't verified that, but from the bug report linked in that issue I believe it does)

r? @alexcrichton