### PR TITLE
Remind LLVM about alloc function names in Rust

### DIFF
--- a/include/llvm/Analysis/TargetLibraryInfo.def
+++ b/include/llvm/Analysis/TargetLibraryInfo.def
@@ -200,6 +200,26 @@ TLI_DEFINE_STRING_INTERNAL("__memset_chk")
 TLI_DEFINE_ENUM_INTERNAL(nvvm_reflect)
 TLI_DEFINE_STRING_INTERNAL("__nvvm_reflect")
 
+/// uint8_t *__rust_allocate(size_t size, size_t align)
+TLI_DEFINE_ENUM_INTERNAL(rust_allocate)
+TLI_DEFINE_STRING_INTERNAL("__rust_allocate")
+
+/// uint8_t *__rust_allocate_zeroed(size_t size, size_t align)
+TLI_DEFINE_ENUM_INTERNAL(rust_allocate_zeroed)
+TLI_DEFINE_STRING_INTERNAL("__rust_allocate_zeroed")
+
+/// void __rust_deallocate(uint8_t *ptr, size_t size, size_t align)
+TLI_DEFINE_ENUM_INTERNAL(rust_deallocate)
+TLI_DEFINE_STRING_INTERNAL("__rust_deallocate")
+
+/// uint8_t *__rust_reallocate(uint8_t *ptr, size_t oldsz, size_t newsz, size_t align)
+TLI_DEFINE_ENUM_INTERNAL(rust_reallocate)
+TLI_DEFINE_STRING_INTERNAL("__rust_reallocate")
+
+/// uint8_t *__rust_reallocate_inplace(uint8_t *ptr, size_t oldsz, size_t newsz, size_t align)
+TLI_DEFINE_ENUM_INTERNAL(rust_reallocate_inplace)
+TLI_DEFINE_STRING_INTERNAL("__rust_reallocate_inplace")
+
 /// double __sincospi_stret(double x);
 TLI_DEFINE_ENUM_INTERNAL(sincospi_stret)
 TLI_DEFINE_STRING_INTERNAL("__sincospi_stret")

--- a/lib/Analysis/MemoryBuiltins.cpp
+++ b/lib/Analysis/MemoryBuiltins.cpp
@@ -73,7 +73,12 @@ static const std::pair<LibFunc::Func, AllocFnsTy> AllocationFnData[] = {
   {LibFunc::realloc,             {ReallocLike, 2, 1,  -1}},
   {LibFunc::reallocf,            {ReallocLike, 2, 1,  -1}},
   {LibFunc::strdup,              {StrDupLike,  1, -1, -1}},
-  {LibFunc::strndup,             {StrDupLike,  2, 1,  -1}}
+  {LibFunc::strndup,             {StrDupLike,  2, 1,  -1}},
+
+  {LibFunc::rust_allocate,       {MallocLike,  2, 0,  -1}},
+  {LibFunc::rust_allocate_zeroed, {MallocLike,  2, 0,  -1}},
+  {LibFunc::rust_reallocate,     {ReallocLike,  4, 2,  -1}},
+  {LibFunc::rust_reallocate_inplace, {ReallocLike,  4, 2,  -1}}
   // TODO: Handle "int posix_memalign(void **, size_t, size_t)"
 };
 
@@ -361,6 +366,8 @@ const CallInst *llvm::isFreeCall(const Value *I, const TargetLibraryInfo *TLI) {
            TLIFn == LibFunc::msvc_delete_array_ptr32_nothrow || // delete[](void*, nothrow)
            TLIFn == LibFunc::msvc_delete_array_ptr64_nothrow)   // delete[](void*, nothrow)
     ExpectedNumParams = 2;
+  else if (TLIFn == LibFunc::rust_deallocate)
+    ExpectedNumParams = 3;
   else
     return nullptr;
 


### PR DESCRIPTION
Port and expansion of 4daef480d1241d040a247440d24013cbdeb741e7