### PR TITLE
Remove reallocate_inplace from memory analysis

### DIFF
--- a/include/llvm/Analysis/TargetLibraryInfo.def
+++ b/include/llvm/Analysis/TargetLibraryInfo.def
@@ -216,10 +216,6 @@ TLI_DEFINE_STRING_INTERNAL("__rust_deallocate")
 TLI_DEFINE_ENUM_INTERNAL(rust_reallocate)
 TLI_DEFINE_STRING_INTERNAL("__rust_reallocate")
 
-/// uint8_t *__rust_reallocate_inplace(uint8_t *ptr, size_t oldsz, size_t newsz, size_t align)
-TLI_DEFINE_ENUM_INTERNAL(rust_reallocate_inplace)
-TLI_DEFINE_STRING_INTERNAL("__rust_reallocate_inplace")
-
 /// double __sincospi_stret(double x);
 TLI_DEFINE_ENUM_INTERNAL(sincospi_stret)
 TLI_DEFINE_STRING_INTERNAL("__sincospi_stret")

--- a/lib/Analysis/MemoryBuiltins.cpp
+++ b/lib/Analysis/MemoryBuiltins.cpp
@@ -78,7 +78,6 @@ static const std::pair<LibFunc::Func, AllocFnsTy> AllocationFnData[] = {
   {LibFunc::rust_allocate,       {MallocLike,  2, 0,  -1}},
   {LibFunc::rust_allocate_zeroed, {MallocLike,  2, 0,  -1}},
   {LibFunc::rust_reallocate,     {ReallocLike,  4, 2,  -1}},
-  {LibFunc::rust_reallocate_inplace, {ReallocLike,  4, 2,  -1}}
   // TODO: Handle "int posix_memalign(void **, size_t, size_t)"
 };
 


### PR DESCRIPTION
It does not return a "new" pointer and therefore it is unclear if it is not
entirely clear whether it is ReallocLike enough.

Removing for now just to be safe.