### PR TITLE
Remove alloc_zeroed optimisation

### DIFF
--- a/lib/Analysis/MemoryBuiltins.cpp
+++ b/lib/Analysis/MemoryBuiltins.cpp
@@ -76,7 +76,6 @@ static const std::pair<LibFunc::Func, AllocFnsTy> AllocationFnData[] = {
   {LibFunc::strndup,             {StrDupLike,  2, 1,  -1}},
 
   {LibFunc::rust_allocate,       {MallocLike,  2, 0,  -1}},
-  {LibFunc::rust_allocate_zeroed, {MallocLike,  2, 0,  -1}},
   {LibFunc::rust_reallocate,     {ReallocLike,  4, 2,  -1}},
   // TODO: Handle "int posix_memalign(void **, size_t, size_t)"
 };


### PR DESCRIPTION
It causes some weird UB-ey interaction in rustc_data_structures.