### PR TITLE
[DO NOT MERGE] Simplify CFG between IndVarSimplify and LoopIdiomRecognize

### DIFF
--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -315,6 +315,7 @@ void PassManagerBuilder::addFunctionSimplificationPasses(
   MPM.add(createCFGSimplificationPass());
   addInstructionCombiningPass(MPM);
   MPM.add(createIndVarSimplifyPass());        // Canonicalize indvars
+  MPM.add(createCFGSimplificationPass());     // Clean up after IndVarSimplify.
   MPM.add(createLoopIdiomPass());             // Recognize idioms like memset.
   MPM.add(createLoopDeletionPass());          // Delete dead loops
   if (EnableLoopInterchange) {


### PR DESCRIPTION
# WARNING: I'm not sure what incantation is needed so that bors try will find this commit, but this should NOT be merged into Rust's LLVM repo until we do some testing.

This ensures that information is properly propagated when IndVarSimplify
removes an overflow check.