### PR TITLE
Mark MergedLoadStoreMotion as not preserving MemDep results

### DIFF
--- a/test/Transforms/GVN/pr36063.ll
+++ b/test/Transforms/GVN/pr36063.ll
@@ -1,0 +1,22 @@
+; RUN: opt < %s -memcpyopt -mldst-motion -gvn -S | FileCheck %s
+
+define void @foo(i8* %ret, i1 %x) {
+  %a = alloca i8
+  br i1 %x, label %yes, label %no
+
+yes:                                              ; preds = %0
+  %gepa = getelementptr i8, i8* %a, i64 0
+  store i8 5, i8* %gepa
+  br label %out
+
+no:                                               ; preds = %0
+  %gepb = getelementptr i8, i8* %a, i64 0
+  store i8 5, i8* %gepb
+  br label %out
+
+out:                                              ; preds = %no, %yes
+  %tmp = load i8, i8* %a
+; CHECK-NOT: undef
+  store i8 %tmp, i8* %ret
+  ret void
+}


### PR DESCRIPTION
Summary:
MemDep caches results that signify that a dependence is non-local, and
there is currently no way to invalidate such cache entries.
Unfortunately, when MLSM sinks a store that can result in a non-local
dependence becoming a local one, and then MemDep gives wrong answers.
The easiest way out here is to just say that MLSM does indeed not
preserve MemDep results.

Reviewers: davide, Gerolf

Subscribers: llvm-commits

Differential Revision: https://reviews.llvm.org/D43177