### PR TITLE
[Sparc] Include __tls_get_addr in symbol table for TLS calls to it

### DIFF
--- a/lib/Target/Sparc/MCTargetDesc/SparcMCExpr.cpp
+++ b/lib/Target/Sparc/MCTargetDesc/SparcMCExpr.cpp
@@ -194,14 +194,30 @@ static void fixELFSymbolsInTLSFixupsImpl(const MCExpr *Expr, MCAssembler &Asm) {
 void SparcMCExpr::fixELFSymbolsInTLSFixups(MCAssembler &Asm) const {
   switch(getKind()) {
   default: return;
+  case VK_Sparc_TLS_GD_CALL:
+  case VK_Sparc_TLS_LDM_CALL: {
+    // The corresponding relocations reference __tls_get_addr, as they call it,
+    // but this is only implicit; there is no connection in the ELF file
+    // between the relocation and the symbol, other than the specification for
+    // the semantics of the relocations. However, the symbol must be included
+    // in our symbol table despite the lack of references to it, since it needs
+    // to be bound during linking for these relocations. For details see
+    // https://sourceware.org/bugzilla/show_bug.cgi?id=22832.
+    MCSymbol *Symbol = Asm.getContext().getOrCreateSymbol("__tls_get_addr");
+    Asm.registerSymbol(*Symbol);
+    auto ELFSymbol = cast<MCSymbolELF>(Symbol);
+    if (!ELFSymbol->isBindingSet()) {
+      ELFSymbol->setBinding(ELF::STB_GLOBAL);
+      ELFSymbol->setExternal(true);
+    }
+    LLVM_FALLTHROUGH;
+  }
   case VK_Sparc_TLS_GD_HI22:
   case VK_Sparc_TLS_GD_LO10:
   case VK_Sparc_TLS_GD_ADD:
-  case VK_Sparc_TLS_GD_CALL:
   case VK_Sparc_TLS_LDM_HI22:
   case VK_Sparc_TLS_LDM_LO10:
   case VK_Sparc_TLS_LDM_ADD:
-  case VK_Sparc_TLS_LDM_CALL:
   case VK_Sparc_TLS_LDO_HIX22:
   case VK_Sparc_TLS_LDO_LOX10:
   case VK_Sparc_TLS_LDO_ADD:

--- a/test/CodeGen/SPARC/tls.ll
+++ b/test/CodeGen/SPARC/tls.ll
@@ -3,10 +3,10 @@
 ; RUN: llc <%s -march=sparc   -relocation-model=pic    | FileCheck %s --check-prefix=pic
 ; RUN: llc <%s -march=sparcv9 -relocation-model=pic    | FileCheck %s --check-prefix=pic
 
-; RUN: llc <%s -march=sparc   -relocation-model=static -filetype=obj | llvm-readobj -r | FileCheck %s --check-prefix=v8abs-obj
-; RUN: llc <%s -march=sparcv9 -relocation-model=static -filetype=obj | llvm-readobj -r | FileCheck %s --check-prefix=v9abs-obj
-; RUN: llc <%s -march=sparc   -relocation-model=pic    -filetype=obj | llvm-readobj -r | FileCheck %s --check-prefix=pic-obj
-; RUN: llc <%s -march=sparcv9 -relocation-model=pic    -filetype=obj | llvm-readobj -r | FileCheck %s --check-prefix=pic-obj
+; RUN: llc <%s -march=sparc   -relocation-model=static -filetype=obj | llvm-readobj -r -t | FileCheck %s --check-prefix=v8abs-obj
+; RUN: llc <%s -march=sparcv9 -relocation-model=static -filetype=obj | llvm-readobj -r -t | FileCheck %s --check-prefix=v9abs-obj
+; RUN: llc <%s -march=sparc   -relocation-model=pic    -filetype=obj | llvm-readobj -r -t | FileCheck %s --check-prefix=pic-obj
+; RUN: llc <%s -march=sparcv9 -relocation-model=pic    -filetype=obj | llvm-readobj -r -t | FileCheck %s --check-prefix=pic-obj
 
 @local_symbol = internal thread_local global i32 0
 @extern_symbol = external thread_local global i32
@@ -116,4 +116,15 @@ entry:
 ; pic-obj:    0x{{[0-9,A-F]+}} R_SPARC_TLS_GD_ADD extern_symbol 0x0
 ; pic-obj:    0x{{[0-9,A-F]+}} R_SPARC_TLS_GD_CALL extern_symbol 0x0
 ; pic-obj: ]
+; pic-obj:      Symbols [
+; pic-obj:        Symbol {
+; pic-obj:          Name: __tls_get_addr ({{[0-9]+}})
+; pic-obj-NEXT:     Value: 0x0
+; pic-obj-NEXT:     Size: 0
+; pic-obj-NEXT:     Binding: Global (0x1)
+; pic-obj-NEXT:     Type: None (0x0)
+; pic-obj-NEXT:     Other: 0
+; pic-obj-NEXT:     Section: Undefined (0x0)
+; pic-obj-NEXT:   }
+; pic-obj:      ]
 


### PR DESCRIPTION
Upstream fix for LLVM on SPARC which is currently in review:

> https://reviews.llvm.org/D43271

This fix is required to fix the code generation in LLVM on SPARC. Without the patch, LLVM generates incorrect code over which binutils stumble and bail out with an internal error, see:

> https://sourceware.org/bugzilla/show_bug.cgi?id=22832

The patch has already been merged in the Debian packages for LLVM 4.0, 5.0 and 6.0.

CC @jrtc27