### PR TITLE
Merging r326358: Fix libexecinfo detection on FreeBSD and NetBSD.

### DIFF
--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -12,8 +12,13 @@ elseif( CMAKE_HOST_UNIX )
   if( HAVE_LIBDL )
     set(system_libs ${system_libs} ${CMAKE_DL_LIBS})
   endif()
-  if( HAVE_BACKTRACE )
-    set(system_libs ${system_libs} ${Backtrace_LIBRARIES})
+  if( HAVE_BACKTRACE AND NOT "${Backtrace_LIBRARIES}" STREQUAL "" )
+    # On BSDs, CMake returns a fully qualified path to the backtrace library.
+    # We need to remove the path and the 'lib' prefix, to make it look like a
+    # regular short library name, suitable for appending to a -l link flag.
+    get_filename_component(Backtrace_LIBFILE ${Backtrace_LIBRARIES} NAME_WE)
+    STRING(REGEX REPLACE "^lib" "" Backtrace_LIBFILE ${Backtrace_LIBFILE})
+    set(system_libs ${system_libs} ${Backtrace_LIBFILE})
   endif()
   if(LLVM_ENABLE_TERMINFO)
     if(HAVE_TERMINFO)


### PR DESCRIPTION
```
------------------------------------------------------------------------
r326358 | dim | 2018-02-28 12:04:21 -0800 (Wed, 28 Feb 2018) | 29 lines
Changed paths:
   M /llvm/trunk/lib/Support/CMakeLists.txt

Fix llvm-config --system-libs output on FreeBSD and NetBSD

Summary:
For various reasons, CMake's detection mechanism for `backtrace()`
returns an absolute path `/usr/lib/libexecinfo.so` on FreeBSD and
NetBSD.

Since `tools/llvm-config/CMakeLists.txt` only checks if system
libraries start with `-`, this causes `llvm-config --system-libs` to
produce the following incorrect output:

```
-lrt -l/usr/lib/libexecinfo.so -ltinfo -lpthread -lz -lm
```

Fix it by removing the path and the `lib` prefix, to make it look like a
regular short library name, suitable for appending to a `-l` link flag.

This also fixes the `Bindings/Go/go.test` test case, since that always
died with "unable to find library -l/usr/lib/libexecinfo.so".

Reviewers: chandlerc, emaste, joerg, krytarowski

Reviewed By: krytarowski

Subscribers: hans, bdrewery, mgorny, hintonda, llvm-commits

Differential Revision: https://reviews.llvm.org/D42702
------------------------------------------------------------------------
```