### PR TITLE
Place undefined globals in .bss instead of .data

### DIFF
--- a/test/CodeGen/ARM/memfunc.ll
+++ b/test/CodeGen/ARM/memfunc.ll
@@ -421,8 +421,10 @@ entry:
 ; CHECK: arr5:
 ; CHECK-NOT: .p2align
 ; CHECK: arr6:
-; CHECK: .p2align 4
-; CHECK: arr8:
+; CHECK-IOS: arr8,128,4
+; CHECK-DARWIN: arr8,128,4
+; CHECK-EABI: arr8,128,16
+; CHECK-GNUEABI: arr8,128,16
 ; CHECK: .p2align 4
 ; CHECK: arr9:
 

--- a/test/CodeGen/X86/undef-globals-bss.ll
+++ b/test/CodeGen/X86/undef-globals-bss.ll
@@ -1,0 +1,12 @@
+; RUN: llc < %s | FileCheck %s
+target triple = "x86_64-apple-darwin"
+
+; CHECK: .zerofill __DATA,__bss,_vals,8000000,2 ## @vals
+@vals = internal unnamed_addr global [2000000 x i32] undef, align 4
+
+; CHECK: .zerofill __DATA,__bss,_struct,8000040,3 ## @struct
+@struct = internal global { i1, [8000000 x i8], [7 x i8], i64, { [4 x i32], { i8 }, i1 } }
+                { i1 false, [8000000 x i8] zeroinitializer, [7 x i8] undef, i64 0,
+                        { [4 x i32], { i8 }, i1 }
+                        { [4 x i32] zeroinitializer, { i8 } { i8 undef }, i1 false }
+                }, align 8


### PR DESCRIPTION
Merge the fix for https://github.com/rust-lang/rust/issues/41315, moving undefined global constants to the bss section instead of the data section.

cc @japaric