### PR TITLE
[WebAssembly] Fix the opcode number for i64.load16_u.

### DIFF
--- a/lib/Target/WebAssembly/WebAssemblyInstrMemory.td
+++ b/lib/Target/WebAssembly/WebAssemblyInstrMemory.td
@@ -151,7 +151,7 @@ def LOAD16_U_I32 : WebAssemblyLoad<I32, "i32.load16_u", 0x2f>;
 def LOAD8_S_I64 : WebAssemblyLoad<I64, "i64.load8_s", 0x30>;
 def LOAD8_U_I64 : WebAssemblyLoad<I64, "i64.load8_u", 0x31>;
 def LOAD16_S_I64 : WebAssemblyLoad<I64, "i64.load16_s", 0x32>;
-def LOAD16_U_I64 : WebAssemblyLoad<I64, "i64.load16_u", 0x32>;
+def LOAD16_U_I64 : WebAssemblyLoad<I64, "i64.load16_u", 0x33>;
 def LOAD32_S_I64 : WebAssemblyLoad<I64, "i64.load32_s", 0x34>;
 def LOAD32_U_I64 : WebAssemblyLoad<I64, "i64.load32_u", 0x35>;
 


### PR DESCRIPTION
Fixes PR37488.


git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@332561 91177308-0d34-0410-b5e6-96231b3b80d8