### PR TITLE
Backport fix for compiling with GCC 8

### DIFF
--- a/include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h
+++ b/include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h
@@ -687,7 +687,7 @@ private:
 
   uint32_t getTrampolineSize() const { return RemoteTrampolineSize; }
 
-  Expected<std::vector<char>> readMem(char *Dst, JITTargetAddress Src,
+  Expected<std::vector<uint8_t>> readMem(char *Dst, JITTargetAddress Src,
                                       uint64_t Size) {
     // Check for an 'out-of-band' error, e.g. from an MM destructor.
     if (ExistingError)


### PR DESCRIPTION
Backported from https://github.com/llvm-mirror/llvm/commit/30e9aa60fea44210ac8d843d2f6a4b3bd2578bf4

Tested only compilation and only on i686 and x86_64 GNU targets.

cc @alexcrichton 