### PR TITLE
Ensure that variant part discriminator is read by MetadataLoader

### DIFF
--- a/lib/Bitcode/Reader/MetadataLoader.cpp
+++ b/lib/Bitcode/Reader/MetadataLoader.cpp
@@ -1311,7 +1311,7 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
                            (Context, Tag, Name, File, Line, Scope, BaseType,
                             SizeInBits, AlignInBits, OffsetInBits, Flags,
                             Elements, RuntimeLang, VTableHolder, TemplateParams,
-                            Identifier));
+                            Identifier, Discriminator));
     if (!IsNotUsedInTypeRef && Identifier)
       MetadataList.addTypeRef(*Identifier, *cast<DICompositeType>(CT));
 

--- a/test/Assembler/debug-variant-discriminator.ll
+++ b/test/Assembler/debug-variant-discriminator.ll
@@ -1,0 +1,14 @@
+; RUN: llvm-as < %s | llvm-dis | llvm-as | llvm-dis | FileCheck %s
+; RUN: verify-uselistorder %s
+
+; CHECK: !named = !{!0, !1, !2}
+!named = !{!0, !1, !2}
+
+; CHECK: !0 = !DICompositeType(tag: DW_TAG_structure_type, name: "Outer", size: 64, align: 64, identifier: "Outer")
+; CHECK-NEXT: !1 = !DICompositeType(tag: DW_TAG_variant_part, scope: !0, size: 64, discriminator: !2)
+; CHECK-NEXT: !2 = !DIDerivedType(tag: DW_TAG_member, scope: !1, baseType: !3, size: 64, align: 64, flags: DIFlagArtificial)
+; CHECK-NEXT: !3 = !DIBasicType(name: "u64", size: 64, encoding: DW_ATE_unsigned)
+!0 = !DICompositeType(tag: DW_TAG_structure_type, name: "Outer", size: 64, align: 64, identifier: "Outer")
+!1 = !DICompositeType(tag: DW_TAG_variant_part, scope: !0, size: 64, discriminator: !2)
+!2 = !DIDerivedType(tag: DW_TAG_member, scope: !1, baseType: !3, size: 64, align: 64, flags: DIFlagArtificial)
+!3 = !DIBasicType(name: "u64", size: 64, encoding: DW_ATE_unsigned)


### PR DESCRIPTION
https://reviews.llvm.org/D42082 introduced variant parts to debug info
in LLVM.  Subsequent work on the Rust compiler has found a bug in that
patch; namely, there is a path in MetadataLoader that fails to restore
the discriminator.

This patch fixes the bug.

This was accepted by upstream LLVM here: https://reviews.llvm.org/D52340
It is needed for https://github.com/rust-lang/rust/pull/54004