### PR TITLE
Remove duplicate copy of WebAssembly::TargetIndex

### DIFF
--- a/lib/Target/WebAssembly/WebAssembly.h
+++ b/lib/Target/WebAssembly/WebAssembly.h
@@ -86,10 +86,6 @@ namespace WebAssembly {
 enum TargetIndex { TI_LOCAL_START, TI_GLOBAL_START, TI_OPERAND_STACK_START };
 } // end namespace WebAssembly
 
-namespace WebAssembly {
-enum TargetIndex { TI_LOCAL_START, TI_GLOBAL_START, TI_OPERAND_STACK_START };
-} // end namespace WebAssembly
-
 } // end namespace llvm
 
 #endif


### PR DESCRIPTION
Commit 9c870ef82e introduced a copy of WebAssembly::TargetIndex,
causing the build to fail on x86-64 Fedora 29.

This patch fixes the problem by removing the second copy.

CC @yurydelendik